### PR TITLE
Set `OwnerReferences` in backup secret metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,9 @@ replace github.com/AthenZ/k8s-athenz-sia/pkg/k8s => ./pkg/k8s
 replace golang.org/x/net => golang.org/x/net v0.7.0
 
 require (
-	github.com/AthenZ/athenz v1.11.23
+	github.com/AthenZ/athenz v1.11.24
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1
 	github.com/pkg/errors v0.9.1
 	github.com/yahoo/k8s-athenz-identity v0.0.0-20210320000321-b0ce39fad833
 	k8s.io/api v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AthenZ/athenz v1.11.23 h1:Iqw46nJHVhDXcnVbXvtl7b7s9tU8xkWHALJ0IKXfOcg=
-github.com/AthenZ/athenz v1.11.23/go.mod h1:d2da1Gn5JLLrV48feSAKYJAJ2xCQPESvHpN5hnseB10=
+github.com/AthenZ/athenz v1.11.24 h1:RY3IRFbVwmc3BKPJPw7yUn1kRdtghcAEOpipBrMQMdM=
+github.com/AthenZ/athenz v1.11.24/go.mod h1:d2da1Gn5JLLrV48feSAKYJAJ2xCQPESvHpN5hnseB10=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -83,6 +83,8 @@ github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 h1:tDQ1LjKga657layZ4JLsRdxgvupebc0xuPwRNuTfUgs=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
# Description

Set `OwnerReferences` in backup secret to allow cascading delete when the owner service account deleted. 

```console
% kubectl get secret
NAME               TYPE                DATA   AGE
my-backup-secret   kubernetes.io/tls   2      44s
% kubectl delete sa my-sa
serviceaccount "my-sa" deleted
% kubectl get secret
No resources found in default namespace.
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
