### PR TITLE
SIA creates a directory for role certificates if not present

### DIFF
--- a/pkg/identity/certificated.go
+++ b/pkg/identity/certificated.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -86,6 +87,11 @@ func Certificated(idConfig *config.IdentityConfig, stopChan <-chan struct{}) (er
 		}
 
 		if roleCerts != nil {
+			// Create the directory before saving role certificates
+			if err := os.MkdirAll(idConfig.RoleCertDir, 0755); err != nil {
+				return errors.Wrap(err, "unable to create directory for x509 role cert")
+			}
+
 			for _, rolecert := range roleCerts {
 				roleCertPEM := []byte(rolecert.X509Certificate)
 				if len(roleCertPEM) != 0 {


### PR DESCRIPTION
# Description

While you can modify `ROLECERT_DIR` to change the directory path for generating role certificates using SIA, if the specified directory doesn't exist, the operation will fail.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
