### PR TITLE
Fix So That SIA does NOT Write Instance Cert When Local File Backup Used

### DIFF
--- a/pkg/identity/certificated.go
+++ b/pkg/identity/certificated.go
@@ -264,8 +264,7 @@ func Certificated(idConfig *config.IdentityConfig, stopChan <-chan struct{}) (er
 			log.Infof("Attempting to request renewed x509 certificate to identity provider[%s]...", idConfig.ProviderService)
 			err, forceInitIdentity, forceInitKeyPEM = identityProvisioningRequest(true)
 			if err != nil {
-				// TODO: Maybe Warning instead?
-				log.Errorf("Failed to retrieve renewed x509 certificate from identity provider: %s", err.Error())
+				log.Warnf("Failed to retrieve renewed x509 certificate from identity provider: %s, continuing with the backup certificate from kubernetes secret", err.Error())
 			} else {
 				identity = forceInitIdentity
 				keyPEM = forceInitKeyPEM

--- a/pkg/identity/certificated.go
+++ b/pkg/identity/certificated.go
@@ -61,7 +61,7 @@ func Certificated(idConfig *config.IdentityConfig, stopChan <-chan struct{}) (er
 
 	// identity & keyPEM that will NOT be STORED to the local file system:
 	var localFileKeyPEM []byte
-	var localFileIdentity  *InstanceIdentity
+	var localFileIdentity *InstanceIdentity
 
 	// Write files to local file system
 	writeFiles := func() error {

--- a/pkg/identity/certificated.go
+++ b/pkg/identity/certificated.go
@@ -45,21 +45,26 @@ func Certificated(idConfig *config.IdentityConfig, stopChan <-chan struct{}) (er
 		log.Infof("Role certificate provisioning is disabled with empty options: roles[%s], output directory[%s]", idConfig.TargetDomainRoles, idConfig.RoleCertDir)
 	}
 
-	// identity & keyPEM will be STORED to the local file system:
-	var keyPEM, k8sSecretBackupKeyPEM, forceInitKeyPEM []byte
-	var identity, k8sSecretBackupIdentity, forceInitIdentity *InstanceIdentity
-
-	// identity & keyPEM that will NOT be STORED to the local file system:
-	var localFileKeyPEM []byte
-	var localFileIdentity  *InstanceIdentity
-
 	handler, err := InitIdentityHandler(idConfig)
 	if err != nil {
 		log.Errorf("Failed to initialize client for certificates: %s", err.Error())
 		return err, nil
 	}
 
-	writeFiles := func(roleCerts [](*RoleCertificate), roleKeyPEM []byte) error {
+	// identity & keyPEM will be STORED to the local file system:
+	var keyPEM, k8sSecretBackupKeyPEM, forceInitKeyPEM []byte
+	var identity, k8sSecretBackupIdentity, forceInitIdentity *InstanceIdentity
+
+	// RoleCert Keys and Certs will be STORED to the local file system:
+	var roleKeyPEM []byte
+	var roleCerts [](*RoleCertificate)
+
+	// identity & keyPEM that will NOT be STORED to the local file system:
+	var localFileKeyPEM []byte
+	var localFileIdentity  *InstanceIdentity
+
+	// Write files to local file system
+	writeFiles := func() error {
 		w := util.NewWriter()
 		if identity != nil && localFileKeyPEM == nil && localFileIdentity == nil {
 			leafPEM := []byte(identity.X509CertificatePEM)
@@ -267,12 +272,12 @@ func Certificated(idConfig *config.IdentityConfig, stopChan <-chan struct{}) (er
 			}
 		}
 
-		err, roleCerts, roleKeyPEM := roleCertProvisioningRequest()
+		err, roleCerts, roleKeyPEM = roleCertProvisioningRequest()
 		if err != nil {
 			return err
 		}
 
-		err = writeFiles(roleCerts, roleKeyPEM)
+		err = writeFiles()
 		if err != nil {
 			if forceInitIdentity != nil || forceInitKeyPEM != nil {
 				log.Errorf("Failed to save files for renewed key[%s], renewed cert[%s] and renewed certificates for roles[%v]", idConfig.KeyFile, idConfig.CertFile, idConfig.TargetDomainRoles)


### PR DESCRIPTION
# Background
When k8s-athenz-sia is used as sidecar, it should not try to write instance cert, when localBackup is used in the red sqaure.
![image](https://github.com/AthenZ/k8s-athenz-sia/assets/53258958/ce754f96-d3cb-448d-95a9-1feb0c7396a7)

## TODOs
- [x] Fix the logic
- [x] Operation Check


