### PR TITLE
expose cached token expires in metrics

### DIFF
--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -59,8 +59,8 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 
 	// initialize token cache with placeholder
 	tokenExpiryInSecond := int(idConfig.TokenExpiry.Seconds())
-	accessTokenCache := NewLockedTokenCache()
-	roleTokenCache := NewLockedTokenCache()
+	accessTokenCache := NewLockedTokenCache("accesstoken")
+	roleTokenCache := NewLockedTokenCache("roletoken")
 	targets := strings.Split(idConfig.TargetDomainRoles, ",")
 	if idConfig.TargetDomainRoles != "" || len(targets) != 1 {
 		for _, dr := range targets {
@@ -114,6 +114,8 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 	}, func() float64 {
 		return float64(roleTokenCache.Len())
 	})
+	prometheus.DefaultRegisterer.MustRegister(accessTokenCache)
+	prometheus.DefaultRegisterer.MustRegister(roleTokenCache)
 
 	ztsClient, err := newZTSClient(idConfig.KeyFile, idConfig.CertFile, idConfig.ServerCACert, idConfig.Endpoint)
 	if err != nil {


### PR DESCRIPTION
# Description

## TODO

- [ ] finalize metrics interface
- [ ] refactor

## changes

### metrics

```console
$ curl -sSi http://127.0.0.1:9999/metrics | grep token_expiry_timestamp
# HELP token_expiry_timestamp Expiry time in seconds since Unix epoch.
# TYPE token_expiry_timestamp gauge
token_expiry_timestamp{domain="domain1",role="role1",type="accesstoken"} 1.703606237e+09
token_expiry_timestamp{domain="domain1",role="role1",type="roletoken"} 1.703606237e+09
token_expiry_timestamp{domain="domain2",role="role2",type="accesstoken"} 1.703606352e+09
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
