### PR TITLE
add tag to git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = x509-certificate-exporter
 	url = https://github.com/enix/x509-certificate-exporter.git
 	branch = main
+	tag = v3.12.0

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,7 @@ submodule-update:
 
 submodule-update-remote:
 	git submodule update --recursive --init --remote
+
+submodule-use-tag:
+	# please update tag in .gitmodules before using this command, tag is not git submodule standard
+	git submodule foreach --recursive 'tag="$$(git config -f $$toplevel/.gitmodules submodule.$$name.tag)";[[ -n $$tag ]] && git reset --hard  $$tag || echo "$$name module has no tag"'


### PR DESCRIPTION
# Description

- git submodule does support tag by default. Add `make submodule-use-tag` to allow using submodule with tag.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
