### PR TITLE
Fix Env TOKEN_SERVER_ENVOY_API -> USE_TOKEN_SERVER

### DIFF
--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -210,7 +210,7 @@ METRICS_SERVER_ADDR=
 #
 DELETE_INSTANCE_ID=true
 #
-# Enable token server Envoy API
+# Enable header token server
 # Available values are: true, false
 #
 HEADER_TOKEN_SERVER=

--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -210,10 +210,12 @@ METRICS_SERVER_ADDR=
 #
 DELETE_INSTANCE_ID=true
 #
-# Enable header token server
+# Enable token server
+# When enabled, runs a server that appends AccessToken and RoleToken to the request headers,
+# aligning with the de facto standard adopted by widely-used proxies such as Envoy, nginx, etc.
 # Available values are: true, false
 #
-HEADER_TOKEN_SERVER=
+USE_TOKEN_SERVER=
 #
 # Directory to store the log files (e.g. /var/log/athenz-sia)
 #

--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -213,7 +213,7 @@ DELETE_INSTANCE_ID=true
 # Enable token server Envoy API
 # Available values are: true, false
 #
-TOKEN_SERVER_ENVOY_API=
+HEADER_TOKEN_SERVER=
 #
 # Directory to store the log files (e.g. /var/log/athenz-sia)
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,7 +97,7 @@ func (idConfig *IdentityConfig) loadFromENV() error {
 	loadEnv("TOKEN_DIR", &idConfig.TokenDir)
 	loadEnv("METRICS_SERVER_ADDR", &idConfig.MetricsServerAddr)
 	loadEnv("DELETE_INSTANCE_ID", &idConfig.rawDeleteInstanceID)
-	loadEnv("TOKEN_SERVER_ENVOY_API", &idConfig.rawTokenServerEnvoyAPI)
+	loadEnv("HEADER_TOKEN_SERVER", &idConfig.rawHeaderTokenServer)
 
 	loadEnv("LOG_DIR", &idConfig.LogDir)
 	loadEnv("LOG_LEVEL", &idConfig.LogLevel)
@@ -146,9 +146,9 @@ func (idConfig *IdentityConfig) loadFromENV() error {
 	if err != nil {
 		return fmt.Errorf("Invalid DELETE_INSTANCE_ID [%q], %v", idConfig.rawDeleteInstanceID, err)
 	}
-	idConfig.TokenServerEnvoyAPI, err = strconv.ParseBool(idConfig.rawTokenServerEnvoyAPI)
+	idConfig.HeaderTokenServer, err = strconv.ParseBool(idConfig.rawHeaderTokenServer)
 	if err != nil {
-		return fmt.Errorf("Invalid TOKEN_SERVER_ENVOY_API [%q], %v", idConfig.rawTokenServerEnvoyAPI, err)
+		return fmt.Errorf("Invalid HEADER_TOKEN_SERVER [%q], %v", idConfig.rawHeaderTokenServer, err)
 	}
 	idConfig.ShutdownTimeout, err = time.ParseDuration(idConfig.rawShutdownTimeout)
 	if err != nil {
@@ -202,8 +202,8 @@ func (idConfig *IdentityConfig) loadFromFlag(program string, args []string) erro
 	f.StringVar(&idConfig.TokenDir, "token-dir", idConfig.TokenDir, "directory to write token files")
 	f.StringVar(&idConfig.MetricsServerAddr, "metrics-server-addr", idConfig.MetricsServerAddr, "HTTP server address to provide metrics")
 	f.BoolVar(&idConfig.DeleteInstanceID, "delete-instance-id", idConfig.DeleteInstanceID, "delete x509 certificate record from identity provider on shutdown (true/false)")
-	// Envoy API
-	f.BoolVar(&idConfig.TokenServerEnvoyAPI, "token-server-envoy-api", idConfig.TokenServerEnvoyAPI, "enable token server Envoy API (true/false)")
+	// Header Token Server
+	f.BoolVar(&idConfig.HeaderTokenServer, "token-server-envoy-api", idConfig.HeaderTokenServer, "enable token server Envoy API (true/false)")
 	// log
 	f.StringVar(&idConfig.LogDir, "log-dir", idConfig.LogDir, "directory to store the log files")
 	f.StringVar(&idConfig.LogLevel, "log-level", idConfig.LogLevel, "logging level")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -202,7 +202,7 @@ func (idConfig *IdentityConfig) loadFromFlag(program string, args []string) erro
 	f.StringVar(&idConfig.TokenDir, "token-dir", idConfig.TokenDir, "directory to write token files")
 	f.StringVar(&idConfig.MetricsServerAddr, "metrics-server-addr", idConfig.MetricsServerAddr, "HTTP server address to provide metrics")
 	f.BoolVar(&idConfig.DeleteInstanceID, "delete-instance-id", idConfig.DeleteInstanceID, "delete x509 certificate record from identity provider on shutdown (true/false)")
-	// Header Token Server
+	// Token Server
 	f.BoolVar(&idConfig.UseTokenServer, "use-token-server", idConfig.UseTokenServer, "enable token server (true/false)")
 	// log
 	f.StringVar(&idConfig.LogDir, "log-dir", idConfig.LogDir, "directory to store the log files")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,7 +203,7 @@ func (idConfig *IdentityConfig) loadFromFlag(program string, args []string) erro
 	f.StringVar(&idConfig.MetricsServerAddr, "metrics-server-addr", idConfig.MetricsServerAddr, "HTTP server address to provide metrics")
 	f.BoolVar(&idConfig.DeleteInstanceID, "delete-instance-id", idConfig.DeleteInstanceID, "delete x509 certificate record from identity provider on shutdown (true/false)")
 	// Header Token Server
-	f.BoolVar(&idConfig.HeaderTokenServer, "token-server-envoy-api", idConfig.HeaderTokenServer, "enable token server Envoy API (true/false)")
+	f.BoolVar(&idConfig.HeaderTokenServer, "header-token-server", idConfig.HeaderTokenServer, "enable header token server (true/false)")
 	// log
 	f.StringVar(&idConfig.LogDir, "log-dir", idConfig.LogDir, "directory to store the log files")
 	f.StringVar(&idConfig.LogLevel, "log-level", idConfig.LogLevel, "logging level")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,7 +97,7 @@ func (idConfig *IdentityConfig) loadFromENV() error {
 	loadEnv("TOKEN_DIR", &idConfig.TokenDir)
 	loadEnv("METRICS_SERVER_ADDR", &idConfig.MetricsServerAddr)
 	loadEnv("DELETE_INSTANCE_ID", &idConfig.rawDeleteInstanceID)
-	loadEnv("HEADER_TOKEN_SERVER", &idConfig.rawHeaderTokenServer)
+	loadEnv("USE_TOKEN_SERVER", &idConfig.rawUseTokenServer)
 
 	loadEnv("LOG_DIR", &idConfig.LogDir)
 	loadEnv("LOG_LEVEL", &idConfig.LogLevel)
@@ -146,9 +146,9 @@ func (idConfig *IdentityConfig) loadFromENV() error {
 	if err != nil {
 		return fmt.Errorf("Invalid DELETE_INSTANCE_ID [%q], %v", idConfig.rawDeleteInstanceID, err)
 	}
-	idConfig.HeaderTokenServer, err = strconv.ParseBool(idConfig.rawHeaderTokenServer)
+	idConfig.UseTokenServer, err = strconv.ParseBool(idConfig.rawUseTokenServer)
 	if err != nil {
-		return fmt.Errorf("Invalid HEADER_TOKEN_SERVER [%q], %v", idConfig.rawHeaderTokenServer, err)
+		return fmt.Errorf("Invalid USE_TOKEN_SERVER [%q], %v", idConfig.rawUseTokenServer, err)
 	}
 	idConfig.ShutdownTimeout, err = time.ParseDuration(idConfig.rawShutdownTimeout)
 	if err != nil {
@@ -203,7 +203,7 @@ func (idConfig *IdentityConfig) loadFromFlag(program string, args []string) erro
 	f.StringVar(&idConfig.MetricsServerAddr, "metrics-server-addr", idConfig.MetricsServerAddr, "HTTP server address to provide metrics")
 	f.BoolVar(&idConfig.DeleteInstanceID, "delete-instance-id", idConfig.DeleteInstanceID, "delete x509 certificate record from identity provider on shutdown (true/false)")
 	// Header Token Server
-	f.BoolVar(&idConfig.HeaderTokenServer, "header-token-server", idConfig.HeaderTokenServer, "enable header token server (true/false)")
+	f.BoolVar(&idConfig.UseTokenServer, "use-token-server", idConfig.UseTokenServer, "enable token server (true/false)")
 	// log
 	f.StringVar(&idConfig.LogDir, "log-dir", idConfig.LogDir, "directory to store the log files")
 	f.StringVar(&idConfig.LogLevel, "log-level", idConfig.LogLevel, "logging level")

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -105,7 +105,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		HealthCheckAddr:           "",
 		HealthCheckEndpoint:       "",
 		DeleteInstanceID:          true,
-		TokenServerEnvoyAPI:       false,
+		HeaderTokenServer:         false,
 		ShutdownTimeout:           DEFAULT_SHUTDOWN_TIMEOUT,
 		ShutdownDelay:             DEFAULT_SHUTDOWN_DELAY,
 
@@ -121,7 +121,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		rawTokenServerRESTAPI:    "false",
 		rawTokenServerTimeout:    DEFAULT_TOKEN_SERVER_TIMEOUT.String(),
 		rawDeleteInstanceID:      "true",
-		rawTokenServerEnvoyAPI:   "false",
+		rawHeaderTokenServer:     "false",
 		rawShutdownTimeout:       DEFAULT_SHUTDOWN_TIMEOUT.String(),
 		rawShutdownDelay:         DEFAULT_SHUTDOWN_DELAY.String(),
 	}

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -105,7 +105,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		HealthCheckAddr:           "",
 		HealthCheckEndpoint:       "",
 		DeleteInstanceID:          true,
-		HeaderTokenServer:         false,
+		UseTokenServer:            false,
 		ShutdownTimeout:           DEFAULT_SHUTDOWN_TIMEOUT,
 		ShutdownDelay:             DEFAULT_SHUTDOWN_DELAY,
 
@@ -121,7 +121,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		rawTokenServerRESTAPI:    "false",
 		rawTokenServerTimeout:    DEFAULT_TOKEN_SERVER_TIMEOUT.String(),
 		rawDeleteInstanceID:      "true",
-		rawHeaderTokenServer:     "false",
+		rawUseTokenServer:        "false",
 		rawShutdownTimeout:       DEFAULT_SHUTDOWN_TIMEOUT.String(),
 		rawShutdownDelay:         DEFAULT_SHUTDOWN_DELAY.String(),
 	}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -63,7 +63,7 @@ type IdentityConfig struct {
 	HealthCheckAddr           string
 	HealthCheckEndpoint       string
 	DeleteInstanceID          bool
-	HeaderTokenServer         bool
+	UseTokenServer            bool
 	ShutdownTimeout           time.Duration
 	ShutdownDelay             time.Duration
 
@@ -80,7 +80,7 @@ type IdentityConfig struct {
 	rawTokenServerRESTAPI    string
 	rawTokenServerTimeout    string
 	rawDeleteInstanceID      string
-	rawHeaderTokenServer     string
+	rawUseTokenServer        string
 	rawShutdownTimeout       string
 	rawShutdownDelay         string
 }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -63,7 +63,7 @@ type IdentityConfig struct {
 	HealthCheckAddr           string
 	HealthCheckEndpoint       string
 	DeleteInstanceID          bool
-	TokenServerEnvoyAPI       bool
+	HeaderTokenServer         bool
 	ShutdownTimeout           time.Duration
 	ShutdownDelay             time.Duration
 
@@ -80,7 +80,7 @@ type IdentityConfig struct {
 	rawTokenServerRESTAPI    string
 	rawTokenServerTimeout    string
 	rawDeleteInstanceID      string
-	rawTokenServerEnvoyAPI   string
+	rawHeaderTokenServer     string
 	rawShutdownTimeout       string
 	rawShutdownDelay         string
 }

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -56,7 +56,7 @@ type daemon struct {
 	tokenExpiryInSecond int
 	roleAuthHeader      string
 
-	headerTokenServer bool
+	useTokenServer bool
 }
 
 func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
@@ -156,7 +156,7 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 		tokenExpiryInSecond: tokenExpiryInSecond,
 		roleAuthHeader:      idConfig.RoleAuthHeader,
 
-		headerTokenServer: idConfig.HeaderTokenServer,
+		useTokenServer: idConfig.UseTokenServer,
 	}, nil
 }
 

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -56,7 +56,7 @@ type daemon struct {
 	tokenExpiryInSecond int
 	roleAuthHeader      string
 
-	tokenEnvoyAPI bool
+	headerTokenServer bool
 }
 
 func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
@@ -156,7 +156,7 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 		tokenExpiryInSecond: tokenExpiryInSecond,
 		roleAuthHeader:      idConfig.RoleAuthHeader,
 
-		tokenEnvoyAPI: idConfig.TokenServerEnvoyAPI,
+		headerTokenServer: idConfig.HeaderTokenServer,
 	}, nil
 }
 

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -218,7 +218,7 @@ func newHandlerFunc(d *daemon, timeout time.Duration) http.Handler {
 			}
 		}
 
-		if !d.tokenEnvoyAPI {
+		if !d.headerTokenServer {
 			w.WriteHeader(http.StatusNotFound)
 			io.WriteString(w, string("404 page not found"))
 			return

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -224,7 +224,7 @@ func newHandlerFunc(d *daemon, timeout time.Duration) http.Handler {
 			return
 		}
 
-		// token server that attaches tokens to the response headers logic begins:
+		// Logic for the token server that attaches tokens to response headers begins here:
 		domain := r.Header.Get(DOMAIN_HEADER)
 		role := r.Header.Get(ROLE_HEADER)
 

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -218,12 +218,13 @@ func newHandlerFunc(d *daemon, timeout time.Duration) http.Handler {
 			}
 		}
 
-		if !d.headerTokenServer {
+		if !d.useTokenServer {
 			w.WriteHeader(http.StatusNotFound)
 			io.WriteString(w, string("404 page not found"))
 			return
 		}
-		// API for envoy (all methods and paths)
+
+		// token server that attaches tokens to the response headers logic begins:
 		domain := r.Header.Get(DOMAIN_HEADER)
 		role := r.Header.Get(ROLE_HEADER)
 


### PR DESCRIPTION
# Description
https://github.com/AthenZ/k8s-athenz-sia/issues/80

## TODOs
- [x] Actual understanding of the logic
- [x] Choose which name would fit to the feature we provide
  - Attaching tokens in the header is the de facto standard used by Envoy, nginx and other proxies and therefore there is no needed to clearly define what the feature does. We choose to use the `USE_TOKEN_SERVER` as the token server should attach the token in the header side (world standard)
- [x] Modify TOKEN_SERVER_ENVOY_API -> USE_TOKEN_SERVER
- [x] Double check and mimic https://github.com/AthenZ/k8s-athenz-sia/pull/78/files
- [x] Some comments must be modified
- [x] Add v4.0.0 with other boolean variables follow the prefix `USE_`
  - https://github.com/AthenZ/k8s-athenz-sia/issues/65

