### PR TITLE
Golang Singleflight for fetching at/rt to zts server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -53,6 +53,7 @@ func (k CacheKey) UniqueId(tokenType string) string {
 	return tokenType + d + k.Domain + d + k.Role + d + strconv.Itoa(k.MaxExpiry) + d + strconv.Itoa(k.MinExpiry) + d + k.ProxyForPrincipal
 }
 
+// String returns CacheKey's information in a string format, usually for logging purpose.
 func (k CacheKey) String() string {
 	return fmt.Sprintf("{%s:role.%s,%s,%d,%d}", k.Domain, k.Role, k.ProxyForPrincipal, k.MinExpiry, k.MaxExpiry)
 }

--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -16,6 +16,7 @@ package token
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 	"unsafe"
@@ -40,6 +41,16 @@ type CacheKey struct {
 	MinExpiry         int
 	ProxyForPrincipal string
 	Role              string
+}
+
+// UniqueId returns a unique id of this token,
+// ensuring that the id stays unique with Athenz naming rules.
+// Athenz domain naming rule: "[a-zA-Z0-9_][a-zA-Z0-9_-]*")
+// Athenz role naming rule: "[a-zA-Z0-9_][a-zA-Z0-9_-]*"
+// and therefore delimiter "|" is used to separate domain and role for uniqueness.
+func (k CacheKey) UniqueId(tokenType string) string {
+	d := "|" // delimiter; using not allowed character for domain/role
+	return tokenType + d + k.Domain + d + k.Role + d + strconv.Itoa(k.MaxExpiry) + d + strconv.Itoa(k.MinExpiry) + d + k.ProxyForPrincipal
 }
 
 func (k CacheKey) String() string {

--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -17,6 +17,7 @@ package token
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -50,7 +51,7 @@ type CacheKey struct {
 // and therefore delimiter "|" is used to separate domain and role for uniqueness.
 func (k CacheKey) UniqueId(tokenType string) string {
 	d := "|" // delimiter; using not allowed character for domain/role
-	return tokenType + d + k.Domain + d + k.Role + d + strconv.Itoa(k.MaxExpiry) + d + strconv.Itoa(k.MinExpiry) + d + k.ProxyForPrincipal
+	return strings.Join([]string{tokenType, k.Domain, k.Role, strconv.Itoa(k.MaxExpiry), strconv.Itoa(k.MinExpiry), k.ProxyForPrincipal}, d)
 }
 
 // String returns CacheKey's information in a string format, usually for logging purpose.

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -282,22 +282,12 @@ func (d *daemon) updateTokenWithRetry(key CacheKey, tt mode) error {
 
 func (d *daemon) updateToken(key CacheKey, tt mode) error {
 	updateAccessToken := func(key CacheKey) error {
-		at, err := fetchAccessToken(d.ztsClient, key, d.saService)
-		if err != nil {
-			return err
-		}
-		d.accessTokenCache.Store(key, at)
-		log.Debugf("Successfully received token from Athenz ZTS server: accessTokens(%s, len=%d)", key, len(at.Raw()))
-		return nil
+		_, err := d.requestTokenToZts(key, mACCESS_TOKEN, "daemon_access_token_update")
+		return err
 	}
 	updateRoleToken := func(key CacheKey) error {
-		rt, err := fetchRoleToken(d.ztsClient, key)
-		if err != nil {
-			return err
-		}
-		d.roleTokenCache.Store(key, rt)
-		log.Debugf("Successfully received token from Athenz ZTS server: roleTokens(%s, len=%d)", key, len(rt.Raw()))
-		return nil
+		_, err := d.requestTokenToZts(key, mROLE_TOKEN, "daemon_access_token_update")
+		return err
 	}
 
 	switch tt {

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -217,7 +217,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 
 	if shared && result.requestID != requestID { // if it is shared and not the actual performer:
 		if err == nil {
-			log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), result.requestID, requestID)
+			log.Infof("Successfully updated %s cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", tokenName, k.String(), result.requestID, requestID)
 		} else {
 			log.Debugf("Failed to fetch %s while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", tokenName, k.String(), result.requestID, requestID, err)
 		}

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -170,6 +170,7 @@ type GroupDoResult struct {
 
 // requestTokenToZts sends a request to ZTS server to fetch either role token or access token.
 // for mode, it only accepts mROLE_TOKEN or mACCESS_TOKEN
+// it also stores in cache for you after successful fetch.
 func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupDoResult, error) {
 	tokenName := "" // tokenName is used for logger (role token or access token only)
 	isRoleTokenRequested := m == mROLE_TOKEN

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -213,7 +213,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 	})
 
 	result := r.(GroupDoResult)
-	log.Debugf("requestID: [%s] handledRequestId: [%s] roleToken: [%s]", requestID, result.requestID, result.token)
+	log.Debugf("requestID: [%s] handledRequestId: [%s] target: [%s]", requestID, result.requestID, k.String())
 
 	if shared && result.requestID != requestID { // if it is shared and not the actual performer:
 		if err == nil {

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -219,7 +219,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 		if err == nil {
 			log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), result.requestID, requestID)
 		} else {
-			log.Debugf("Failed to fetch role token while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", k.String(), result.requestID, requestID, err)
+			log.Debugf("Failed to fetch %s while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", tokenName, k.String(), result.requestID, requestID, err)
 		}
 	}
 

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -162,6 +162,70 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 	}, nil
 }
 
+// GroupDoResult contains token and its requestID after singleFlight.group.Do()
+type GroupDoResult struct {
+	requestID string
+	token     Token
+}
+
+// requestTokenToZts sends a request to ZTS server to fetch either role token or access token.
+// for mode, it only accepts mROLE_TOKEN or mACCESS_TOKEN
+func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupDoResult, error) {
+	tokenName := "" // tokenName is used for logger (role token or access token only)
+	isRoleTokenRequested := m == mROLE_TOKEN
+	isAccessTokenRequested := m == mACCESS_TOKEN
+
+	if isRoleTokenRequested {
+		tokenName = "role token"
+	} else if isAccessTokenRequested {
+		tokenName = "access token"
+	} else {
+		return GroupDoResult{requestID: requestID, token: nil}, fmt.Errorf("Invalid token type: %d", d.tokenType)
+	}
+
+	// TODO: Is this really for cache miss? I don't think so.
+	log.Debugf("Attempting to fetch %s due to a cache miss from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+
+	r, err, shared := d.group.Do(k.UniqueId(tokenName), func() (interface{}, error) {
+		// define variables before request to ZTS
+		var fetchedToken Token
+		var err error
+
+		if isRoleTokenRequested {
+			fetchedToken, err = fetchRoleToken(d.ztsClient, k)
+		} else { // isAccessTokenRequested
+			fetchedToken, err = fetchAccessToken(d.ztsClient, k, d.saService)
+		}
+
+		if err != nil {
+			log.Debugf("Failed to fetch %s from Athenz ZTS server after a cache miss: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+			return GroupDoResult{requestID: requestID, token: nil}, err
+		}
+
+		if isRoleTokenRequested {
+			d.roleTokenCache.Store(k, fetchedToken)
+		} else { // isAccessTokenRequested
+			d.accessTokenCache.Store(k, fetchedToken)
+		}
+
+		log.Infof("Successfully updated %s cache after a cache miss: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+		return GroupDoResult{requestID: requestID, token: fetchedToken}, nil
+	})
+
+	result := r.(GroupDoResult)
+	log.Debugf("requestID: [%s] handledRequestId: [%s] roleToken: [%s]", requestID, result.requestID, result.token)
+
+	if shared && result.requestID != requestID { // if it is shared and not the actual performer:
+		if err == nil {
+			log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), result.requestID, requestID)
+		} else {
+			log.Debugf("Failed to fetch role token while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", k.String(), result.requestID, requestID, err)
+		}
+	}
+
+	return result, err
+}
+
 func (d *daemon) updateTokenCaches() <-chan error {
 	var atErrorCount, rtErrorCount atomic.Int64
 	atTargets := d.accessTokenCache.Keys()

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -181,7 +181,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 	} else if isAccessTokenRequested {
 		tokenName = "access token"
 	} else {
-		return GroupDoResult{requestID: requestID, token: nil}, fmt.Errorf("Invalid token type: %d", d.tokenType)
+		return GroupDoResult{requestID: requestID, token: nil}, fmt.Errorf("Invalid mode: %d", m)
 	}
 
 	log.Debugf("Attempting to fetch %s from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/config"
 	extutil "github.com/AthenZ/k8s-athenz-sia/v3/pkg/util"
@@ -39,6 +40,7 @@ import (
 )
 
 type daemon struct {
+	group            singleflight.Group
 	accessTokenCache TokenCache
 	roleTokenCache   TokenCache
 

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -184,8 +184,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 		return GroupDoResult{requestID: requestID, token: nil}, fmt.Errorf("Invalid token type: %d", d.tokenType)
 	}
 
-	// TODO: Is this really for cache miss? I don't think so.
-	log.Debugf("Attempting to fetch %s due to a cache miss from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+	log.Debugf("Attempting to fetch %s from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 
 	r, err, shared := d.group.Do(k.UniqueId(tokenName), func() (interface{}, error) {
 		// define variables before request to ZTS
@@ -199,7 +198,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 		}
 
 		if err != nil {
-			log.Debugf("Failed to fetch %s from Athenz ZTS server after a cache miss: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+			log.Debugf("Failed to fetch %s from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 			return GroupDoResult{requestID: requestID, token: nil}, err
 		}
 
@@ -209,7 +208,7 @@ func (d *daemon) requestTokenToZts(k CacheKey, m mode, requestID string) (GroupD
 			d.accessTokenCache.Store(k, fetchedToken)
 		}
 
-		log.Infof("Successfully updated %s cache after a cache miss: target[%s], requestID[%s]", tokenName, k.String(), requestID)
+		log.Infof("Successfully updated %s cache: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 		return GroupDoResult{requestID: requestID, token: fetchedToken}, nil
 	})
 
@@ -287,7 +286,7 @@ func (d *daemon) updateToken(key CacheKey, tt mode) error {
 		return err
 	}
 	updateRoleToken := func(key CacheKey) error {
-		_, err := d.requestTokenToZts(key, mROLE_TOKEN, "daemon_access_token_update")
+		_, err := d.requestTokenToZts(key, mROLE_TOKEN, "daemon_role_token_update")
 		return err
 	}
 

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -39,11 +39,11 @@ type GroupDoResult struct {
 }
 
 // requestTokenToZts sends a request to ZTS server to fetch either role token or access token.
-// It will return invalid token type for any others.
-func requestTokenToZts(d *daemon, k CacheKey, requestID string) (GroupDoResult, error) {
+// for mode, it only accepts mROLE_TOKEN or mACCESS_TOKEN
+func requestTokenToZts(d *daemon, k CacheKey, m mode, requestID string) (GroupDoResult, error) {
 	tokenName := "" // tokenName is used for logger (role token or access token only)
-	isRoleTokenRequested := d.tokenType&mROLE_TOKEN != 0
-	isAccessTokenRequested := d.tokenType&mACCESS_TOKEN != 0
+	isRoleTokenRequested := m == mROLE_TOKEN
+	isAccessTokenRequested := m == mACCESS_TOKEN
 
 	if isRoleTokenRequested {
 		tokenName = "role token"
@@ -150,7 +150,7 @@ func postRoleToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if rToken == nil || time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
-		res, err := requestTokenToZts(d, k, requestID)
+		res, err := requestTokenToZts(d, k, mROLE_TOKEN, requestID)
 		if err != nil {
 			return
 		}
@@ -226,7 +226,7 @@ func postAccessToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if aToken == nil || time.Unix(aToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
-		res, err := requestTokenToZts(d, k, requestID)
+		res, err := requestTokenToZts(d, k, mACCESS_TOKEN, requestID)
 		if err != nil {
 			return
 		}

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -56,7 +56,7 @@ func requestTokenToZts(d *daemon, k CacheKey, tokenName, requestID, domain, role
 	// TODO: Is this really for cache miss? I don't think so.
 	log.Debugf("Attempting to fetch %s due to a cache miss from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 
-	r, err, shared := d.group.Do(getKey(roleToken, domain, role), func() (interface{}, error) {
+	r, err, shared := d.group.Do(getKey(tokenName, domain, role), func() (interface{}, error) {
 		// define variables before request to ZTS
 		var fetchedToken Token
 		var err error
@@ -76,7 +76,12 @@ func requestTokenToZts(d *daemon, k CacheKey, tokenName, requestID, domain, role
 		}
 
 		// update cache
-		d.roleTokenCache.Store(k, fetchedToken)
+		if tokenName == roleToken {
+			d.roleTokenCache.Store(k, fetchedToken)
+		} else {
+			d.accessTokenCache.Store(k, fetchedToken)
+		}
+
 		log.Infof("Successfully updated %s cache after a cache miss: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 		return GroupDoHandledResult{requestID: requestID, token: fetchedToken}, nil
 	})

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -53,10 +53,6 @@ type GroupDoHandledResult struct {
 
 // requestTokenToZts sends a request to ZTS server to fetch either role token or access token.
 func requestTokenToZts(d *daemon, k CacheKey, tokenName, requestID, domain, role string) (GroupDoHandledResult, error) {
-	if tokenName != roleToken && tokenName != accessToken {
-		return GroupDoHandledResult{}, fmt.Errorf("Invalid token name: %s", tokenName)
-	}
-
 	// TODO: Is this really for cache miss? I don't think so.
 	log.Debugf("Attempting to fetch %s due to a cache miss from Athenz ZTS server: target[%s], requestID[%s]", tokenName, k.String(), requestID)
 
@@ -68,8 +64,10 @@ func requestTokenToZts(d *daemon, k CacheKey, tokenName, requestID, domain, role
 		// on cache miss, fetch token from Athenz ZTS server
 		if tokenName == roleToken {
 			fetchedToken, err = fetchRoleToken(d.ztsClient, k)
-		} else { // or access token
+		} else if tokenName == accessToken {
 			fetchedToken, err = fetchAccessToken(d.ztsClient, k, d.saService)
+		} else {
+			return GroupDoHandledResult{}, fmt.Errorf("Invalid token name: %s", tokenName)
 		}
 
 		if err != nil {

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -34,7 +34,8 @@ const (
 	accessTokenKeyHeader = "access"
 )
 
-// GroupDoHandledResult contains token and its requestID after single flight
+// GroupDoHandledResult contains token and its requestID after singleFlight.group.Do()
+// TODO: Maybe shorter name for GroupDoHandledResult
 type GroupDoHandledResult struct {
 	requestID string
 	token     Token

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -86,7 +86,8 @@ func postRoleToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if rToken == nil || time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
-		res, err := d.requestTokenToZts(k, mROLE_TOKEN, requestID)
+		res, resErr := d.requestTokenToZts(k, mROLE_TOKEN, requestID)
+		err = resErr // assign error for defer
 		if err != nil {
 			return
 		}
@@ -162,7 +163,8 @@ func postAccessToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if aToken == nil || time.Unix(aToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
-		res, err := d.requestTokenToZts(k, mACCESS_TOKEN, requestID)
+		res, resErr := d.requestTokenToZts(k, mACCESS_TOKEN, requestID)
+		err = resErr // assign error for defer
 		if err != nil {
 			return
 		}

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -34,13 +34,6 @@ const (
 	accessToken   = "access token"
 )
 
-// GroupDoHandledResult contains token and its requestID after singleFlight.group.Do()
-// TODO: Maybe shorter name for GroupDoHandledResult
-type GroupDoHandledResult struct {
-	requestID string
-	token     Token
-}
-
 // getKey returns key for the singleflight.Group,
 // ensuring that the key used in singleflight is unique is important to prevent collisions.
 // Athenz domain naming rule: "[a-zA-Z0-9_][a-zA-Z0-9_-]*")
@@ -51,7 +44,14 @@ func getKey(tokenType, domain, role string) string {
 	return tokenType + d + domain + d + role
 }
 
-// requestTokenToZts sends a request to ZTS server to fetch a token
+// GroupDoHandledResult contains token and its requestID after singleFlight.group.Do()
+// TODO: Maybe shorter name for GroupDoHandledResult
+type GroupDoHandledResult struct {
+	requestID string
+	token     Token
+}
+
+// requestTokenToZts sends a request to ZTS server to fetch either role token or access token.
 func requestTokenToZts(d *daemon, k CacheKey, tokenName, requestID, domain, role string) (GroupDoHandledResult, error) {
 	if tokenName != roleToken && tokenName != accessToken {
 		return GroupDoHandledResult{}, fmt.Errorf("Invalid token name: %s", tokenName)

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -113,9 +113,8 @@ func postRoleToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 			return requestID, nil
 		})
 
-		// if it is shared and not handled by this request, log it
 		handledRequestId := id.(string)
-		if shared && handledRequestId != requestID {
+		if shared && handledRequestId != requestID { // if it is shared and not the actual performer:
 			if err == nil {
 				log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), handledRequestId, requestID)
 			} else {
@@ -207,9 +206,8 @@ func postAccessToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 			return requestID, nil
 		})
 
-		// if it is shared and not handled by this request, log it
 		handledRequestId := id.(string)
-		if shared && handledRequestId != requestID {
+		if shared && handledRequestId != requestID { // if it is shared and not the actual performer:
 			if err == nil {
 				log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), handledRequestId, requestID)
 			} else {

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -82,18 +82,18 @@ func requestTokenToZts(d *daemon, k CacheKey, requestID string) (GroupDoResult, 
 		return GroupDoResult{requestID: requestID, token: fetchedToken}, nil
 	})
 
-	handled := r.(GroupDoResult)
-	log.Debugf("requestID: [%s] handledRequestId: [%s] roleToken: [%s]", requestID, handled.requestID, handled.token)
+	result := r.(GroupDoResult)
+	log.Debugf("requestID: [%s] handledRequestId: [%s] roleToken: [%s]", requestID, result.requestID, result.token)
 
-	if shared && handled.requestID != requestID { // if it is shared and not the actual performer:
+	if shared && result.requestID != requestID { // if it is shared and not the actual performer:
 		if err == nil {
-			log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), handled.requestID, requestID)
+			log.Infof("Successfully updated role token cache by coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s]", k.String(), result.requestID, requestID)
 		} else {
-			log.Debugf("Failed to fetch role token while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", k.String(), handled.requestID, requestID, err)
+			log.Debugf("Failed to fetch role token while coalescing requests to a leader request: target[%s], leaderRequestID[%s], requestID[%s], err[%s]", k.String(), result.requestID, requestID, err)
 		}
 	}
 
-	return handled, err
+	return result, err
 }
 
 func postRoleToken(d *daemon, w http.ResponseWriter, r *http.Request) {

--- a/pkg/token/type.go
+++ b/pkg/token/type.go
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: refactor this type together with other enum flags in config.go (MODE, TOKEN_TYPE, BACKUP)
+
 package token
 
 import "strings"
 
-// TODO: refactor this type together with other enum flags in config.go (MODE, TOKEN_TYPE, BACKUP)
+// mode contains the type of token(s) that the client is requesting
+// 0 (0x00) => no role token or access token
+// 1 (0x01) => access token
+// 2 (0x10) => role token
+// 3 (0x11) => access token + role token
 type mode int
 
 const (


### PR DESCRIPTION
# Description
![image](https://github.com/AthenZ/k8s-athenz-sia/assets/53258958/593edd80-de5f-443d-8d8b-126cca7f1d39)


When handling multiple requests for the same token, it's unnecessary to send several requests to the ZTS server in short span. To optimize this, we can utilize the singleflight feature from the golang.org/x/sync/singleflight package, which ensures that for a given token, only one request is made to the ZTS server, and its result is shared across all the requests.

Also, to effectively monitor whether a specific requestID has been processed using singleflight or not, loggers that allow us to determine whether a request was handled directly or if its response was the result of a shared call to the ZTS serve is a must.

*This is the expected log for single request:*
```sh
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[11111]
Successfully updated role token cache after a cache miss: target[provider.domain.name], requestID[11111]
```

*This is expected log for multiple requests in a short span:*
```sh
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[11111]
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[22222]
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[33333]
Successfully updated role token cache after a cache miss: target[provider.domain.name], requestID[11111]
Successfully updated role token cache by coalescing requests to a leader request: target[yby.jekim.provirder], leaderRequestID[11111], requestID[22222]
Successfully updated role token cache by coalescing requests to a leader request: target[yby.jekim.provide], leaderRequestID[11111], requestID[33333]
```

*This is expected log for multiple requests in a short span but fails:*
```sh
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[11111]
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[22222]
Attempting to fetch role token due to a cache miss from Athenz ZTS server: target[provider.domain.name], requestID[33333]
Failed to fetch role token from Athenz ZTS server after a cache miss: target[provider.domain.name], requestID[11111]
Failed to fetch role token from Athenz ZTS server as a leader request has failed: target[provider.domain.name], leaderRequestID[11111], requestID[22222]
Failed to fetch role token from Athenz ZTS server as a leader request has failed: target[provider.domain.name], leaderRequestID[11111], requestID[33333]
```


## TODOs
- [x] Implement feature
- [x] Do operation check