### PR TITLE
Modify default value for BACKUP feature

### DIFF
--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -65,9 +65,8 @@ INTERMEDIATE_CERT_BUNDLE=
 # "read": read backup from kubernetes secret
 # "write": write backup into kubernetes secret
 # "read+write": read & write backup from/into kubernetes secret
-# Default value for binary: https://github.com/AthenZ/k8s-athenz-sia/blob/c8478297a9d228ffc0a6a1ea469ad0ef8a682dc8/pkg/config/default.go#L77
 #
-BACKUP=read+write
+BACKUP=
 #
 # Kubernetes TLS Secret to backup and load X.509 certificate files
 #

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -74,7 +74,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		CertFile:                  "",
 		CaCertFile:                "",
 		IntermediateCertBundle:    DEFAULT_INTERMEDIATE_CERT_BUNDLE,
-		Backup:                    "read+write",
+		Backup:                    "",
 		CertSecret:                "",
 		Namespace:                 "",
 		AthenzDomain:              "",


### PR DESCRIPTION
# Description

- Fix default value for BACKUP feature from`"read+write"` to `""` 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

- https://github.com/AthenZ/k8s-athenz-sia/issues/90

---

## Checklist

- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
