### PR TITLE
Disable maxExpiry Option When obtaining a role token

### DIFF
--- a/pkg/token/athenz.go
+++ b/pkg/token/athenz.go
@@ -106,14 +106,16 @@ func fetchAccessToken(ztsClient *zts.ZTSClient, t CacheKey, saService string) (*
 
 func fetchRoleToken(ztsClient *zts.ZTSClient, t CacheKey) (*RoleToken, error) {
 	var minExpiry, maxExpiry *int32
-	if t.MinExpiry != 0 {
+	if t.MinExpiry > 0 {
 		e := int32(t.MinExpiry)
 		minExpiry = &e
 	}
-	if t.MaxExpiry != 0 {
-		e := int32(t.MaxExpiry)
-		maxExpiry = &e
-	}
+	// To prevent the Role Token's expiration from being shorter than the ZTS server's default value,
+	// we will ignore the maxExpiry setting value in the request body.
+	// if t.MaxExpiry > 0 {
+	// 	e := int32(t.MaxExpiry)
+	// 	maxExpiry = &e
+	// }
 	roletokenResponse, err := ztsClient.GetRoleToken(zts.DomainName(t.Domain), zts.EntityList(t.Role), minExpiry, maxExpiry, zts.EntityName(t.ProxyForPrincipal))
 	if err != nil || roletokenResponse.Token == "" {
 		return nil, fmt.Errorf("GetRoleToken failed for target [%s], err: %v", t.String(), err)

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -82,13 +82,15 @@ func postRoleToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	if rtRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *rtRequest.ProxyForPrincipal
 	}
-	if rtRequest.MinExpiry != nil {
+	if rtRequest.MinExpiry != nil && *rtRequest.MinExpiry > 0 {
 		k.MinExpiry = *rtRequest.MinExpiry
 	}
-	if rtRequest.MaxExpiry != nil {
-		k.MaxExpiry = *rtRequest.MaxExpiry
-	}
-	if k.MinExpiry == 0 {
+	// To prevent the Role Token's expiration from being shorter than the ZTS server's default value,
+	// we will ignore the maxExpiry setting value in the request body.
+	// if rtRequest.MaxExpiry != nil && *rtRequest.MaxExpiry > 0{
+	// 	k.MaxExpiry = *rtRequest.MaxExpiry
+	// }
+	if k.MinExpiry == 0 && d.tokenExpiryInSecond > 0 {
 		k.MinExpiry = d.tokenExpiryInSecond
 	}
 	// cache lookup (token TTL must >= 1 minute)
@@ -166,10 +168,10 @@ func postAccessToken(d *daemon, w http.ResponseWriter, r *http.Request) {
 	if atRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *atRequest.ProxyForPrincipal
 	}
-	if atRequest.Expiry != nil {
+	if atRequest.Expiry != nil && *atRequest.Expiry > 0 {
 		k.MaxExpiry = *atRequest.Expiry
 	}
-	if k.MaxExpiry == 0 {
+	if k.MaxExpiry == 0 && d.tokenExpiryInSecond > 0 {
 		k.MaxExpiry = d.tokenExpiryInSecond
 	}
 


### PR DESCRIPTION
# Description

- When obtaining a role token, we have made it so that the maxExpiry set in the request body is ignored.
- If there is any minExpiry that is negative, we have made it so that it will be ignored.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
