### PR TITLE
token metrics with k8s namespace and k8s pod name

### DIFF
--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -119,13 +119,6 @@ SA_TOKEN_FILE=
 #
 POD_IP=127.0.0.1
 #
-# Kubernetes Pod Name
-#
-# POD_NAME may be extracted from metadata.name in Kubernetes manifests
-# At this point in Mar 2024, POD_NAME is only used for token cache features
-#
-POD_NAME=
-#
 # Kubernetes Pod UID
 #
 # POD_UID may be extracted from metadata.uid in Kubernetes manifests
@@ -133,6 +126,13 @@ POD_NAME=
 POD_UID=
 #
 # CA certificate to verify ZTS server certificate
+#
+# Kubernetes Pod Name
+#
+# POD_NAME may be extracted from metadata.name in Kubernetes manifests
+# At this point in Mar 2024, POD_NAME is only used for token cache features
+#
+POD_NAME=
 #
 SERVER_CA_CERT=
 #

--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -119,6 +119,13 @@ SA_TOKEN_FILE=
 #
 POD_IP=127.0.0.1
 #
+# Kubernetes Pod Name
+#
+# POD_NAME may be extracted from metadata.name in Kubernetes manifests
+# At this point in Mar 2024, POD_NAME is only used for token cache features
+#
+POD_NAME=
+#
 # Kubernetes Pod UID
 #
 # POD_UID may be extracted from metadata.uid in Kubernetes manifests

--- a/athenz-sia.env
+++ b/athenz-sia.env
@@ -125,14 +125,14 @@ POD_IP=127.0.0.1
 #
 POD_UID=
 #
-# CA certificate to verify ZTS server certificate
-#
 # Kubernetes Pod Name
 #
 # POD_NAME may be extracted from metadata.name in Kubernetes manifests
 # At this point in Mar 2024, POD_NAME is only used for token cache features
 #
 POD_NAME=
+#
+# CA certificate to verify ZTS server certificate
 #
 SERVER_CA_CERT=
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,6 +86,7 @@ func (idConfig *IdentityConfig) loadFromENV() error {
 	loadEnv("SA_TOKEN_FILE", &idConfig.SaTokenFile)
 	loadEnv("POD_IP", &idConfig.rawPodIP)
 	loadEnv("POD_UID", &idConfig.PodUID)
+	loadEnv("POD_NAME", &idConfig.PodName)
 	loadEnv("SERVER_CA_CERT", &idConfig.ServerCACert)
 	loadEnv("TARGET_DOMAIN_ROLES", &idConfig.rawTargetDomainRoles)
 	loadEnv("ROLECERT_DIR", &idConfig.RoleCertDir)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -85,6 +85,7 @@ func DefaultIdentityConfig() *IdentityConfig {
 		SaTokenFile:               "",
 		PodIP:                     net.ParseIP("127.0.0.1"),
 		PodUID:                    "",
+		PodName:                   "",
 		Reloader:                  nil,
 		ServerCACert:              "",
 		TargetDomainRoles:         []DomainRole{},

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -44,6 +44,7 @@ type IdentityConfig struct {
 	SaTokenFile               string
 	PodIP                     net.IP
 	PodUID                    string
+	PodName                   string
 	Reloader                  *util.CertReloader
 	ServerCACert              string
 	TargetDomainRoles         []DomainRole

--- a/pkg/token/daemon.go
+++ b/pkg/token/daemon.go
@@ -62,8 +62,8 @@ func newDaemon(idConfig *config.IdentityConfig, tt mode) (*daemon, error) {
 
 	// initialize token cache with placeholder
 	tokenExpiryInSecond := int(idConfig.TokenExpiry.Seconds())
-	accessTokenCache := NewLockedTokenCache("accesstoken")
-	roleTokenCache := NewLockedTokenCache("roletoken")
+	accessTokenCache := NewLockedTokenCache("accesstoken", idConfig)
+	roleTokenCache := NewLockedTokenCache("roletoken", idConfig)
 	for _, dr := range idConfig.TargetDomainRoles {
 		domain, role := dr.Domain, dr.Role
 		if tt&mACCESS_TOKEN != 0 {


### PR DESCRIPTION
# Background
token metrics now includes `k8s_namespace` and `k8s_pod_name` if the following env exists
- `NAMESPACE`
- `POD_NAME`

sample:
```sh
curl -sfS localhost:9793/metrics | grep token | grep token_expires_in_seconds
# HELP token_expires_in_seconds Indicates remaining time until the token expires
# TYPE token_expires_in_seconds gauge
token_expires_in_seconds{domain="athenz.provider-domain",k8s_namespace="my-namespace",k8s_pod="test-pod-1a2cb7",max_expiry="14400",role="provider-client",type="accesstoken"} 12792.730765255
token_expires_in_seconds{domain="athenz.provider-domain",k8s_namespace="my-namespace",k8s_pod="test-pod-1a2cb7",min_expiry="14400",role="provider-client",type="roletoken"} 12792.730655096
```

## TODOs
- [x] implement new env `POD_NAME`