### PR TITLE
Add user-agent header to ZTS Server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@
 
 LDFLAGS :=
 ifneq ($(ATHENZ_SIA_VERSION),)
-LDFLAGS_ARGS += -X 'main.VERSION=$(ATHENZ_SIA_VERSION)'
+LDFLAGS_ARGS += -X 'github.com/AthenZ/k8s-athenz-sia/v3/pkg/version.VERSION=$(ATHENZ_SIA_VERSION)'
 else
-LDFLAGS_ARGS += -X 'main.VERSION=$(shell git rev-parse --short HEAD)'
+LDFLAGS_ARGS += -X 'github.com/AthenZ/k8s-athenz-sia/v3/pkg/version.VERSION=$(shell git rev-parse --short HEAD)'
 endif
 ifneq ($(ATHENZ_SIA_BUILD_DATE),)
-LDFLAGS_ARGS += -X 'main.BUILD_DATE=$(ATHENZ_SIA_BUILD_DATE)'
+LDFLAGS_ARGS += -X 'github.com/AthenZ/k8s-athenz-sia/v3/pkg/version.BUILD_DATE=$(ATHENZ_SIA_BUILD_DATE)'
 else
-LDFLAGS_ARGS += -X 'main.BUILD_DATE=$(shell date '+%Y-%m-%dT%H:%M:%S%Z%z')'
+LDFLAGS_ARGS += -X 'github.com/AthenZ/k8s-athenz-sia/v3/pkg/version.BUILD_DATE=$(shell date '+%Y-%m-%dT%H:%M:%S%Z%z')'
 endif
 ifneq ($(ATHENZ_SIA_DEFAULT_ENDPOINT),)
 LDFLAGS_ARGS += -X 'github.com/AthenZ/k8s-athenz-sia/v3/pkg/config.DEFAULT_ENDPOINT=$(ATHENZ_SIA_DEFAULT_ENDPOINT)'

--- a/cmd/athenz-sia/main.go
+++ b/cmd/athenz-sia/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/config"
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/identity"
+	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/version"
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -31,8 +32,9 @@ import (
 const serviceName = "athenz-sia"
 
 var (
-	VERSION    string
-	BUILD_DATE string
+	APP_NAME   = version.APP_NAME
+	VERSION    = version.VERSION
+	BUILD_DATE = version.BUILD_DATE
 )
 
 // printVersion returns the version and the built date of the executable itself
@@ -60,7 +62,7 @@ func main() {
 
 	// one-time logger for loading user config
 	log.InitLogger("", "INFO", true)
-	idConfig, err := config.LoadConfig(filepath.Base(os.Args[0]), os.Args[1:])
+	idConfig, err := config.LoadConfig(APP_NAME, os.Args[1:])
 	if err != nil {
 		switch err {
 		case config.ErrHelp:
@@ -74,7 +76,7 @@ func main() {
 
 	// re-init logger from user config
 	log.InitLogger(filepath.Join(idConfig.LogDir, fmt.Sprintf("%s.%s.log", serviceName, idConfig.LogLevel)), idConfig.LogLevel, true)
-	log.Infof("Starting [%s] with version [%s], built on [%s]", filepath.Base(os.Args[0]), VERSION, BUILD_DATE)
+	log.Infof("Starting [%s] with version [%s], built on [%s]", APP_NAME, VERSION, BUILD_DATE)
 	log.Infof("Booting up with args: %v, config: %+v", os.Args, idConfig)
 
 	certificateChan := make(chan struct{}, 1)
@@ -92,7 +94,7 @@ func main() {
 		Name: "sidecar_build_info",
 		Help: "Indicates the application name, build version and date",
 		ConstLabels: prometheus.Labels{
-			"app_name": filepath.Base(os.Args[0]),
+			"app_name": APP_NAME,
 			"version":  VERSION,
 			"built":    BUILD_DATE, // reference: https://github.com/enix/x509-certificate-exporter/blob/b33c43ac520dfbced529bf7543d8271d052947d0/internal/collector.go#L49
 		},

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/config"
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/k8s"
+	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/version"
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/util"
 
@@ -96,6 +97,8 @@ func InitIdentityHandler(config *config.IdentityConfig) (*identityHandler, error
 	}
 
 	client := zts.NewClient(config.Endpoint, t)
+	// Add User-Agent header to ZTS client for fetching x509 certificate
+	client.AddCredentials("User-Agent", fmt.Sprintf("%s/%s", version.APP_NAME, version.VERSION))
 
 	domain := extutil.NamespaceToDomain(config.Namespace, config.AthenzPrefix, config.AthenzDomain, config.AthenzSuffix)
 	service := extutil.ServiceAccountToService(config.ServiceAccount)
@@ -260,6 +263,8 @@ func (h *identityHandler) GetX509RoleCert() (rolecerts [](*RoleCertificate), rol
 	// The intermediate certificates may be different between each ZTS.
 	// Therefore, ZTS Client for PostRoleCertificateRequest must share the same endpoint as PostInstanceRegisterInformation/PostInstanceRefreshInformation
 	roleCertClient := zts.NewClient(h.config.Endpoint, t)
+	// Add User-Agent header to ZTS client for fetching x509 role certificates
+	roleCertClient.AddCredentials("User-Agent", fmt.Sprintf("%s/%s", version.APP_NAME, version.VERSION))
 
 	key, err := PrivateKeyFromPEMBytes(keyPEM)
 	if err != nil {

--- a/pkg/token/athenz.go
+++ b/pkg/token/athenz.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/util"
+	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/version"
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
 	jwt "github.com/golang-jwt/jwt/v5"
 )
@@ -62,6 +63,8 @@ func newZTSClient(reloader *util.CertReloader, serverCAPath, endpoint string) (*
 	// Therefore, ZTS Client for PostRoleCertificateRequest must share the same endpoint as PostInstanceRegisterInformation/PostInstanceRefreshInformation
 	log.Infof("Create ZTS client to fetch tokens: %s, %+v", endpoint, t)
 	ztsClient := zts.NewClient(endpoint, t)
+	// Add User-Agent header to ZTS client for fetching tokens
+	ztsClient.AddCredentials("User-Agent", fmt.Sprintf("%s/%s", version.APP_NAME, version.VERSION))
 	return &ztsClient, nil
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,26 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	APP_NAME   = filepath.Base(os.Args[0])
+	VERSION    string
+	BUILD_DATE string
+)


### PR DESCRIPTION
# Description

Modified request header `User-Agent` to include version of `athenz-sia` when making requests to the ZTS Server.


## Example

- `User-Agent: athenz-sia/v3.2.0`
  - `athenz-sia` changes depending on binary name.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
