### PR TITLE
Fix condition for `r.pollRefresh()`

### DIFF
--- a/pkg/util/tls-reload.go
+++ b/pkg/util/tls-reload.go
@@ -169,7 +169,7 @@ func NewCertReloader(config ReloadConfig) (*CertReloader, error) {
 	}
 
 	// If the following condition is met, the cert reloader will not be used to reload certificates:
-	//   - SIA does not use identityd to issue certificates (or fig.ProviderService == "")/
+	//   - SIA does not use identityd to issue certificates (or fig.ProviderService == "")
 	//   - File paths for certificates and keys are provided.
 	// TODO: Issue created based on this: https://github.com/AthenZ/k8s-athenz-sia/issues/113
 	if config.ProviderService == "" && config.CertFile != "" && config.KeyFile != "" {

--- a/pkg/util/tls-reload.go
+++ b/pkg/util/tls-reload.go
@@ -167,8 +167,12 @@ func NewCertReloader(config ReloadConfig) (*CertReloader, error) {
 		}
 		return nil, err
 	}
-	// If SIA is not issuing certificates, use pollRefresh function to periodically read certificate files and update cert reloader.
-	if config.ProviderService == "" {
+
+	// If the following condition is met, the cert reloader will not be used to reload certificates:
+	//   - SIA does not use identityd to issue certificates (or fig.ProviderService == "")/
+	//   - File paths for certificates and keys are provided.
+	// TODO: Issue created based on this: https://github.com/AthenZ/k8s-athenz-sia/issues/113
+	if config.ProviderService == "" && config.CertFile != "" && config.KeyFile != "" {
 		go r.pollRefresh()
 	}
 	return r, nil

--- a/pkg/util/tls-reload.go
+++ b/pkg/util/tls-reload.go
@@ -170,7 +170,7 @@ func NewCertReloader(config ReloadConfig) (*CertReloader, error) {
 
 	// If the following condition is met, the cert reloader will not be used to reload certificates:
 	//   - SIA does not use identityd to issue certificates (or fig.ProviderService == "")
-	//   - File paths for certificates and keys are provided.
+	//   - File paths for certificates and keys are provided. (or config.CertFile != "" && config.KeyFile != "")
 	// TODO: Issue created based on this: https://github.com/AthenZ/k8s-athenz-sia/issues/113
 	if config.ProviderService == "" && config.CertFile != "" && config.KeyFile != "" {
 		go r.pollRefresh()


### PR DESCRIPTION
# Description

`r.pollRefresh()` must run only when the following condition all met:
- `config.ProviderService == ""`
- `config.CertFile != ""`
- `config.KeyFile != ""`

But current code only checks `config.ProviderService == ""`, and it is a bug.

Reference: 
  - https://github.com/AthenZ/k8s-athenz-sia/blob/main/pkg/certificate/service.go#L188
  - https://github.com/AthenZ/k8s-athenz-sia/blob/main/pkg/certificate/service.go#L199

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
