### PR TITLE
Create token DIR if not exists

### DIFF
--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime/metrics"
 	"sync"
@@ -438,6 +439,11 @@ func (d *tokenService) writeFiles() error {
 	if d.tokenDir == "" {
 		log.Debugf("Skipping to write token files to directory[%s]", d.tokenDir)
 		return nil
+	}
+
+	// Create the directory before saving tokens
+	if err := os.MkdirAll(d.tokenDir, 0755); err != nil {
+		return fmt.Errorf("unable to create directory for tokens: %w", err)
 	}
 
 	w := util.NewWriter()


### PR DESCRIPTION
# Description

- issue: writing to token file will keep failing if token DIR not exists
- changes: create token DIR if not exists

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
