### PR TITLE
InstanceCert without root certificate

### DIFF
--- a/pkg/certificate/identity.go
+++ b/pkg/certificate/identity.go
@@ -203,7 +203,7 @@ func (h *identityHandler) GetX509Cert(forceInit bool) (*InstanceIdentity, []byte
 	}
 
 	identity := &InstanceIdentity{
-		X509CertificatePEM:   id.X509Certificate + id.X509CertificateSigner,
+		X509CertificatePEM:   id.X509Certificate,
 		X509CACertificatePEM: id.X509CertificateSigner,
 	}
 


### PR DESCRIPTION
# Description
ZTS returns root certificate as `id.X509CertificateSigner` and SIA concatenates it for InstanceCert. 

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
