### PR TITLE
log filename follows the binary filename

### DIFF
--- a/cmd/athenz-sia/main.go
+++ b/cmd/athenz-sia/main.go
@@ -33,8 +33,6 @@ import (
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
 )
 
-const serviceName = "athenz-sia"
-
 // printVersion returns the version and the built date of the executable itself
 func printVersion() {
 	if config.VERSION == "" || config.BUILD_DATE == "" {
@@ -74,7 +72,7 @@ func main() {
 	}
 
 	// re-init logger from user config
-	log.InitLogger(filepath.Join(idCfg.LogDir, fmt.Sprintf("%s.%s.log", serviceName, idCfg.LogLevel)), idCfg.LogLevel, true)
+	log.InitLogger(filepath.Join(idCfg.LogDir, fmt.Sprintf("%s.%s.log", config.APP_NAME, idCfg.LogLevel)), idCfg.LogLevel, true)
 	log.Infof("Starting [%s] with version [%s], built on [%s]", config.APP_NAME, config.VERSION, config.BUILD_DATE)
 	log.Infof("Booting up with args: %v, config: %+v", os.Args, idCfg)
 


### PR DESCRIPTION
# Description

log filename should follow the binary filename, instead of using a hard-coded value

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [x] Delete the branch after merge
