### PR TITLE
Writing Token Files Update Individually with Go Routine

### DIFF
--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -28,8 +28,8 @@ import (
 
 type TokenCache interface {
 	Store(k CacheKey, t Token)
-	Search(k CacheKey) (CacheKey, Token)
 	Load(k CacheKey) Token
+	Search(k CacheKey) (CacheKey, Token)
 	Range(func(k CacheKey, t Token) error) error
 	Keys() []CacheKey
 	Size() int64

--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -110,6 +110,12 @@ func (c *LockedTokenCache) Store(k CacheKey, t Token) {
 	}
 }
 
+func (c *LockedTokenCache) Load(k CacheKey) Token {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache[k]
+}
+
 // Search searches for tokens in the cache for the specified domain and role in the cache key,
 // regardless of whether they are subject to file output.
 // If the cache is hit, it returns the cache key and token used at that time.
@@ -131,12 +137,6 @@ func (c *LockedTokenCache) Search(k CacheKey) (CacheKey, Token) {
 	}
 	// If there is no cache hit, it returns the cache key specified in the arguments as is.
 	return k, nil
-}
-
-func (c *LockedTokenCache) Load(k CacheKey) Token {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.cache[k]
 }
 
 func (c *LockedTokenCache) Range(f func(k CacheKey, t Token) error) error {

--- a/pkg/token/cache.go
+++ b/pkg/token/cache.go
@@ -42,6 +42,7 @@ type CacheKey struct {
 	MinExpiry         int
 	ProxyForPrincipal string
 	Role              string
+	WriteFileRequired bool
 }
 
 // UniqueId returns a unique id of this token,

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -78,7 +78,7 @@ func postRoleToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// create cache key
-	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: false}
+	k := CacheKey{Domain: domain, Role: role}
 	if rtRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *rtRequest.ProxyForPrincipal
 	}
@@ -166,7 +166,7 @@ func postAccessToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// create cache key
-	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: false}
+	k := CacheKey{Domain: domain, Role: role}
 	if atRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *atRequest.ProxyForPrincipal
 	}
@@ -259,7 +259,7 @@ func newHandlerFunc(ts *tokenService, timeout time.Duration) http.Handler {
 		} else {
 			// TODO: Since the specifications are not yet decided, the value of WriteFileRequired is undetermined.
 			// TODO: Maybe we need to separate the cache keys for RT and AT?
-			k := CacheKey{Domain: domain, Role: role, MinExpiry: ts.tokenExpiryInSecond, WriteFileRequired: false}
+			k := CacheKey{Domain: domain, Role: role, MinExpiry: ts.tokenExpiryInSecond}
 			if ts.tokenType&mACCESS_TOKEN != 0 {
 				k, aToken = ts.accessTokenCache.Search(k)
 				if aToken == nil {

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -78,8 +78,7 @@ func postRoleToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// create cache key
-	// Prioritize checking the cases that are subject to file output.
-	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: true}
+	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: false}
 	if rtRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *rtRequest.ProxyForPrincipal
 	}
@@ -96,12 +95,8 @@ func postRoleToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// cache lookup (token TTL must >= 1 minute)
-	rToken := ts.roleTokenCache.Load(k)
-	// The case of not being subject to file output.
-	if rToken == nil {
-		k.WriteFileRequired = false
-		rToken = ts.roleTokenCache.Load(k)
-	}
+	var rToken Token
+	k, rToken = ts.roleTokenCache.Search(k)
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if rToken == nil || time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
@@ -171,8 +166,7 @@ func postAccessToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// create cache key
-	// Prioritize checking the cases that are subject to file output.
-	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: true}
+	k := CacheKey{Domain: domain, Role: role, WriteFileRequired: false}
 	if atRequest.ProxyForPrincipal != nil {
 		k.ProxyForPrincipal = *atRequest.ProxyForPrincipal
 	}
@@ -184,12 +178,8 @@ func postAccessToken(ts *tokenService, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// cache lookup (token TTL must >= 1 minute)
-	aToken := ts.accessTokenCache.Load(k)
-	// The case of not being subject to file output.
-	if aToken == nil {
-		k.WriteFileRequired = false
-		aToken = ts.accessTokenCache.Load(k)
-	}
+	var aToken Token
+	k, aToken = ts.accessTokenCache.Search(k)
 	// TODO: What does time.Unix(rToken.Expiry(), 0).Sub(time.Now()) <= time.Minute mean?
 	// TODO: Gotta write a comment for this, or define a variable beforehand.
 	if aToken == nil || time.Unix(aToken.Expiry(), 0).Sub(time.Now()) <= time.Minute {
@@ -268,26 +258,16 @@ func newHandlerFunc(ts *tokenService, timeout time.Duration) http.Handler {
 			errMsg = fmt.Sprintf("http headers not set: %s[%s] %s[%s].", DOMAIN_HEADER, domain, ROLE_HEADER, role)
 		} else {
 			// TODO: Since the specifications are not yet decided, the value of WriteFileRequired is undetermined.
-			// Prioritize checking the cases that are subject to file output.
-			k := CacheKey{Domain: domain, Role: role, MinExpiry: ts.tokenExpiryInSecond, WriteFileRequired: true}
+			// TODO: Maybe we need to separate the cache keys for RT and AT?
+			k := CacheKey{Domain: domain, Role: role, MinExpiry: ts.tokenExpiryInSecond, WriteFileRequired: false}
 			if ts.tokenType&mACCESS_TOKEN != 0 {
-				aToken = ts.accessTokenCache.Load(k)
-				// The case of not being subject to file output.
-				if aToken == nil {
-					k.WriteFileRequired = false
-					aToken = ts.accessTokenCache.Load(k)
-				}
+				k, aToken = ts.accessTokenCache.Search(k)
 				if aToken == nil {
 					errMsg = fmt.Sprintf("domain[%s] role[%s] was not found in cache.", domain, role)
 				}
 			}
 			if ts.tokenType&mROLE_TOKEN != 0 {
-				rToken = ts.roleTokenCache.Load(k)
-				// The case of not being subject to file output.
-				if rToken == nil {
-					k.WriteFileRequired = false
-					rToken = ts.roleTokenCache.Load(k)
-				}
+				k, rToken = ts.roleTokenCache.Search(k)
 				if rToken == nil {
 					errMsg = fmt.Sprintf("domain[%s] role[%s] was not found in cache.", domain, role)
 				}

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -82,19 +82,23 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 	accessTokenCache := NewLockedTokenCache("accesstoken", idCfg.Namespace, idCfg.PodName)
 	roleTokenCache := NewLockedTokenCache("roletoken", idCfg.Namespace, idCfg.PodName)
 	var atTargetDomainRolesToFile, rtTargetDomainRolesToFile []CacheKey
+	// TODO: Rewrite the following if statement as "if tt.isAccessTokenEnabled()..."
 	if tt&mACCESS_TOKEN != 0 {
 		atTargetDomainRolesToFile = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
 	}
+	// TODO: Rewrite the following if statement as "if tt.isRoleTokenEnabled()..."
 	if tt&mROLE_TOKEN != 0 {
 		rtTargetDomainRolesToFile = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
 	}
 	for _, dr := range idCfg.TargetDomainRoles {
 		domain, role := dr.Domain, dr.Role
+		// TODO: Rewrite the following if statement as "if tt.isAccessTokenEnabled()..."
 		if tt&mACCESS_TOKEN != 0 {
 			cacheKey := CacheKey{Domain: domain, Role: role, MaxExpiry: tokenExpiryInSecond}
 			accessTokenCache.Store(cacheKey, &AccessToken{})
 			atTargetDomainRolesToFile = append(atTargetDomainRolesToFile, cacheKey)
 		}
+		// TODO: Rewrite the following if statement as "if tt.isRoleTokenEnabled()..."
 		if tt&mROLE_TOKEN != 0 {
 			cacheKey := CacheKey{Domain: domain, Role: role, MinExpiry: tokenExpiryInSecond}
 			roleTokenCache.Store(cacheKey, &RoleToken{})

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -137,9 +137,8 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 	// If it is in refresh mode, when requesting tokens using the REST API for the domains and roles specified in TARGET_DOMAIN_ROLES,
 	// the cache is updated to ensure a cache hit from the first request.
 	if !idCfg.Init || enableWriteFiles {
-		errs := ts.updateTokenCachesAndWriteFiles(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT)
 		// TODO: if cap(errs) == len(errs), implies all token updates failed, should be fatal
-		for _, err := range errs {
+		for _, err := range ts.updateTokenCachesAndWriteFiles(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT) {
 			log.Errorf("Failed to refresh tokens after multiple retries: %s", err.Error())
 		}
 	}

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -146,7 +146,7 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		shutdownTimeout:           idCfg.ShutdownTimeout,
 	}
 
-	// initialize tokens on mode=refresh or TOKEN_DIR is set
+	// write tokens as files only if it is non-init mode AND TOKEN_DIR is set
 	if !idCfg.Init || idCfg.TokenDir != "" {
 		errs := ts.updateTokenCaches(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT)
 		// TODO: if cap(errs) == len(errs), implies all token updates failed, should be fatal

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -75,7 +75,7 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 	// TODO: In the next PR, the determination will be made on a per Access Token and Role Token basis.
 	enableWriteFiles := idCfg.TokenDir != ""
 	if !enableWriteFiles {
-		log.Debugf("Skipping to write token files to directory")
+		log.Debugf("Skipping to write token files to directory with empty TOKEN_DIR [%s]", idCfg.TokenDir)
 	}
 
 	// initialize token cache with placeholder
@@ -87,13 +87,11 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		domain, role := dr.Domain, dr.Role
 		// TODO: Rewrite the following if statement as "if tt.isAccessTokenEnabled()..."
 		if tt&mACCESS_TOKEN != 0 {
-			cacheKey := CacheKey{Domain: domain, Role: role, MaxExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}
-			accessTokenCache.Store(cacheKey, &AccessToken{})
+			accessTokenCache.Store(CacheKey{Domain: domain, Role: role, MaxExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}, &AccessToken{})
 		}
 		// TODO: Rewrite the following if statement as "if tt.isRoleTokenEnabled()..."
 		if tt&mROLE_TOKEN != 0 {
-			cacheKey := CacheKey{Domain: domain, Role: role, MinExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}
-			roleTokenCache.Store(cacheKey, &RoleToken{})
+			roleTokenCache.Store(CacheKey{Domain: domain, Role: role, MinExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}, &RoleToken{})
 		}
 	}
 
@@ -462,7 +460,7 @@ func (d *tokenService) writeFile(token Token, outPath string, tt mode) error {
 			return fmt.Errorf("unable to create directory for token: %w", err)
 		}
 	}
-
+	// TODO: Attempting to save token file for Domain %s, Role: %s in %s , ... outPath)
 	log.Infof("[Saving %s Token] Domain: %s, Role: %s[%d bytes] in %s", tokenType, domain, role, len(rawToken), outPath)
 	if err := w.AddBytes(outPath, 0644, []byte(rawToken)); err != nil {
 		return fmt.Errorf("unable to save %s Token: %w", tokenType, err)

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -443,6 +443,9 @@ func (d *tokenService) updateToken(key CacheKey, tt mode) error {
 	}
 }
 
+// The latest Access Tokens and Role Tokens in the memory cache will be output to files.
+// The tokens to be output are those specified by the TargetDomainRoles for the domain and roles.
+// If multiple tokens are to be output, the file output process will be executed in parallel using go routines.
 func (d *tokenService) writeFiles(ctx context.Context, maxElapsedTime time.Duration) []error {
 	if d.tokenDir == "" {
 		log.Debugf("Skipping to write token files to directory[%s]", d.tokenDir)
@@ -501,6 +504,7 @@ func (d *tokenService) writeFiles(ctx context.Context, maxElapsedTime time.Durat
 	return errs
 }
 
+// writeFileWithRetry attempts multiple times to write a file for the given token (AT or RT) by utilizing writeFile()
 func (d *tokenService) writeFileWithRetry(ctx context.Context, maxElapsedTime time.Duration, token Token, outPath string, tt mode) error {
 	// backoff config with first retry delay of 5s, and then 10s, 20s, ...
 	b := backoff.NewExponentialBackOff()
@@ -517,6 +521,7 @@ func (d *tokenService) writeFileWithRetry(ctx context.Context, maxElapsedTime ti
 	return backoff.RetryNotify(operation, backoff.WithContext(b, ctx), notifyOnErr)
 }
 
+// writeFile outputs given token (AT or RT) as file
 func (d *tokenService) writeFile(token Token, outPath string, tt mode) error {
 	w := util.NewWriter()
 	tokenType := ""

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -82,10 +82,10 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 	roleTokenCache := NewLockedTokenCache("roletoken", idCfg.Namespace, idCfg.PodName)
 	var atTargetDomainRoles, rtTargetDomainRoles []CacheKey
 	if tt&mACCESS_TOKEN != 0 {
-		atTargetDomainRoles = make([]CacheKey, len(idCfg.TargetDomainRoles))
+		atTargetDomainRoles = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
 	}
 	if tt&mROLE_TOKEN != 0 {
-		rtTargetDomainRoles = make([]CacheKey, len(idCfg.TargetDomainRoles))
+		rtTargetDomainRoles = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
 	}
 	for _, dr := range idCfg.TargetDomainRoles {
 		domain, role := dr.Domain, dr.Role

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -459,6 +459,10 @@ func (d *tokenService) writeFiles(ctx context.Context, maxElapsedTime time.Durat
 			defer wg.Done()
 			domain, role := k.Domain, k.Role
 			token := d.accessTokenCache.Load(k)
+			if token == nil {
+				log.Debugf("Skipping to write access token file for domain[%s] role[%s]", domain, role)
+				return
+			}
 			log.Debugf("next: %s %s %s", domain, role, token.Raw())
 
 			outPath := filepath.Join(d.tokenDir, domain+":role."+role+".accesstoken")
@@ -478,6 +482,10 @@ func (d *tokenService) writeFiles(ctx context.Context, maxElapsedTime time.Durat
 			defer wg.Done()
 			domain, role := k.Domain, k.Role
 			token := d.roleTokenCache.Load(k)
+			if token == nil {
+				log.Debugf("Skipping to write role token file for domain[%s] role[%s]", domain, role)
+				return
+			}
 			log.Debugf("next: %s %s %s", domain, role, token.Raw())
 			outPath := filepath.Join(d.tokenDir, domain+":role."+role+".roletoken")
 			err := d.writeFileWithRetry(ctx, maxElapsedTime, token, outPath, mROLE_TOKEN)

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime/metrics"
 	"sync"
@@ -73,6 +74,9 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 	}
 	// TODO: In the next PR, the determination will be made on a per Access Token and Role Token basis.
 	enableWriteFiles := idCfg.TokenDir != ""
+	if !enableWriteFiles {
+		log.Debugf("Skipping to write token files to directory")
+	}
 
 	// initialize token cache with placeholder
 	tt := newType(idCfg.TokenType)
@@ -449,6 +453,14 @@ func (d *tokenService) writeFile(token Token, outPath string, tt mode) error {
 	if rawToken == "" {
 		// skip placeholder token added during daemon creation
 		return nil
+	}
+
+	// Create the directory before saving tokens
+	dir := filepath.Dir(outPath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("unable to create directory for token: %w", err)
+		}
 	}
 
 	log.Infof("[Saving %s Token] Domain: %s, Role: %s[%d bytes] in %s", tokenType, domain, role, len(rawToken), outPath)

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"runtime/metrics"
 	"sync"
@@ -44,9 +43,6 @@ type tokenService struct {
 	group            singleflight.Group
 	accessTokenCache TokenCache
 	roleTokenCache   TokenCache
-
-	atTargetDomainRolesToFile []CacheKey
-	rtTargetDomainRolesToFile []CacheKey
 
 	// keyFile      string
 	// certFile     string
@@ -75,34 +71,25 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		log.Info("Skipped token provider initiation")
 		return nil, nil
 	}
+	// TODO: In the next PR, the determination will be made on a per Access Token and Role Token basis.
+	enableWriteFiles := idCfg.TokenDir != ""
 
 	// initialize token cache with placeholder
 	tt := newType(idCfg.TokenType)
 	tokenExpiryInSecond := int(idCfg.TokenExpiry.Seconds())
 	accessTokenCache := NewLockedTokenCache("accesstoken", idCfg.Namespace, idCfg.PodName)
 	roleTokenCache := NewLockedTokenCache("roletoken", idCfg.Namespace, idCfg.PodName)
-	var atTargetDomainRolesToFile, rtTargetDomainRolesToFile []CacheKey
-	// TODO: Rewrite the following if statement as "if tt.isAccessTokenEnabled()..."
-	if tt&mACCESS_TOKEN != 0 {
-		atTargetDomainRolesToFile = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
-	}
-	// TODO: Rewrite the following if statement as "if tt.isRoleTokenEnabled()..."
-	if tt&mROLE_TOKEN != 0 {
-		rtTargetDomainRolesToFile = make([]CacheKey, 0, len(idCfg.TargetDomainRoles))
-	}
 	for _, dr := range idCfg.TargetDomainRoles {
 		domain, role := dr.Domain, dr.Role
 		// TODO: Rewrite the following if statement as "if tt.isAccessTokenEnabled()..."
 		if tt&mACCESS_TOKEN != 0 {
-			cacheKey := CacheKey{Domain: domain, Role: role, MaxExpiry: tokenExpiryInSecond}
+			cacheKey := CacheKey{Domain: domain, Role: role, MaxExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}
 			accessTokenCache.Store(cacheKey, &AccessToken{})
-			atTargetDomainRolesToFile = append(atTargetDomainRolesToFile, cacheKey)
 		}
 		// TODO: Rewrite the following if statement as "if tt.isRoleTokenEnabled()..."
 		if tt&mROLE_TOKEN != 0 {
-			cacheKey := CacheKey{Domain: domain, Role: role, MinExpiry: tokenExpiryInSecond}
+			cacheKey := CacheKey{Domain: domain, Role: role, MinExpiry: tokenExpiryInSecond, WriteFileRequired: enableWriteFiles}
 			roleTokenCache.Store(cacheKey, &RoleToken{})
-			rtTargetDomainRolesToFile = append(rtTargetDomainRolesToFile, cacheKey)
 		}
 	}
 
@@ -128,33 +115,30 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 
 	// setup token service
 	ts := &tokenService{
-		shutdownChan:              make(chan struct{}, 1),
-		accessTokenCache:          accessTokenCache,
-		roleTokenCache:            roleTokenCache,
-		atTargetDomainRolesToFile: atTargetDomainRolesToFile,
-		rtTargetDomainRolesToFile: rtTargetDomainRolesToFile,
-		ztsClient:                 ztsClient,
-		saService:                 saService,
-		tokenRESTAPI:              idCfg.TokenServerRESTAPI,
-		tokenType:                 tt,
-		tokenDir:                  idCfg.TokenDir,
-		tokenRefresh:              idCfg.TokenRefresh,
-		tokenExpiryInSecond:       tokenExpiryInSecond,
-		roleAuthHeader:            idCfg.RoleAuthHeader,
-		useTokenServer:            idCfg.UseTokenServer,
-		shutdownDelay:             idCfg.ShutdownDelay,
-		shutdownTimeout:           idCfg.ShutdownTimeout,
+		shutdownChan:        make(chan struct{}, 1),
+		accessTokenCache:    accessTokenCache,
+		roleTokenCache:      roleTokenCache,
+		ztsClient:           ztsClient,
+		saService:           saService,
+		tokenRESTAPI:        idCfg.TokenServerRESTAPI,
+		tokenType:           tt,
+		tokenDir:            idCfg.TokenDir,
+		tokenRefresh:        idCfg.TokenRefresh,
+		tokenExpiryInSecond: tokenExpiryInSecond,
+		roleAuthHeader:      idCfg.RoleAuthHeader,
+		useTokenServer:      idCfg.UseTokenServer,
+		shutdownDelay:       idCfg.ShutdownDelay,
+		shutdownTimeout:     idCfg.ShutdownTimeout,
 	}
 
-	// write tokens as files only if it is non-init mode AND TOKEN_DIR is set
-	if !idCfg.Init || idCfg.TokenDir != "" {
-		errs := ts.updateTokenCaches(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT)
+	// write tokens as files only if it is non-init mode OR TOKEN_DIR is set
+	// If it is in refresh mode, when requesting tokens using the REST API for the domains and roles specified in TARGET_DOMAIN_ROLES,
+	// the cache is updated to ensure a cache hit from the first request.
+	if !idCfg.Init || enableWriteFiles {
+		errs := ts.updateTokenCachesAndWriteFiles(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT)
 		// TODO: if cap(errs) == len(errs), implies all token updates failed, should be fatal
 		for _, err := range errs {
 			log.Errorf("Failed to refresh tokens after multiple retries: %s", err.Error())
-		}
-		for _, err := range ts.writeFiles(ctx, config.DEFAULT_MAX_ELAPSED_TIME_ON_INIT) {
-			log.Errorf("Failed to write token files after multiple retries: %s", err.Error())
 		}
 	}
 
@@ -239,12 +223,8 @@ func (ts *tokenService) Start(ctx context.Context) error {
 					}
 
 					// backoff retry until TOKEN_REFRESH_INTERVAL / 4 OR context is done
-					for _, err := range ts.updateTokenCaches(ctx, ts.tokenRefresh/4) {
+					for _, err := range ts.updateTokenCachesAndWriteFiles(ctx, ts.tokenRefresh/4) {
 						log.Errorf("Failed to refresh tokens after multiple retries: %s", err.Error())
-					}
-					// backoff retry until TOKEN_REFRESH_INTERVAL / 4 OR context is done
-					for _, err := range ts.writeFiles(ctx, ts.tokenRefresh/4) {
-						log.Errorf("Failed to write token files after multiple retries: %s", err.Error())
 					}
 				}
 			}
@@ -361,7 +341,7 @@ func (ts *tokenService) requestTokenToZts(k CacheKey, m mode, requestID string) 
 	return result, err
 }
 
-func (ts *tokenService) updateTokenCaches(ctx context.Context, maxElapsedTime time.Duration) []error {
+func (ts *tokenService) updateTokenCachesAndWriteFiles(ctx context.Context, maxElapsedTime time.Duration) []error {
 	var atErrorCount, rtErrorCount atomic.Int64
 	atTargets := ts.accessTokenCache.Keys()
 	rtTargets := ts.roleTokenCache.Keys()
@@ -374,7 +354,7 @@ func (ts *tokenService) updateTokenCaches(ctx context.Context, maxElapsedTime ti
 		wg.Add(1)
 		go func(key CacheKey) {
 			defer wg.Done()
-			err := ts.updateTokenWithRetry(ctx, maxElapsedTime, key, mACCESS_TOKEN)
+			err := ts.updateAndWriteFileTokenWithRetry(ctx, maxElapsedTime, key, mACCESS_TOKEN)
 			if err != nil {
 				echan <- err
 				atErrorCount.Add(1)
@@ -386,7 +366,7 @@ func (ts *tokenService) updateTokenCaches(ctx context.Context, maxElapsedTime ti
 		wg.Add(1)
 		go func(key CacheKey) {
 			defer wg.Done()
-			err := ts.updateTokenWithRetry(ctx, maxElapsedTime, key, mROLE_TOKEN)
+			err := ts.updateAndWriteFileTokenWithRetry(ctx, maxElapsedTime, key, mROLE_TOKEN)
 			if err != nil {
 				echan <- err
 				rtErrorCount.Add(1)
@@ -407,9 +387,9 @@ func (ts *tokenService) updateTokenCaches(ctx context.Context, maxElapsedTime ti
 	return errs
 }
 
-func (ts *tokenService) updateTokenWithRetry(ctx context.Context, maxElapsedTime time.Duration, key CacheKey, tt mode) error {
+func (ts *tokenService) updateAndWriteFileTokenWithRetry(ctx context.Context, maxElapsedTime time.Duration, key CacheKey, tt mode) error {
 	operation := func() error {
-		return ts.updateToken(key, tt)
+		return ts.updateAndWriteFileToken(key, tt)
 	}
 	notifyOnErr := func(err error, backoffDelay time.Duration) {
 		log.Errorf("Failed to refresh tokens: %s. Retrying in %s", err.Error(), backoffDelay)
@@ -417,96 +397,37 @@ func (ts *tokenService) updateTokenWithRetry(ctx context.Context, maxElapsedTime
 	return backoff.RetryNotify(operation, newExponentialBackOff(ctx, maxElapsedTime), notifyOnErr)
 }
 
-func (d *tokenService) updateToken(key CacheKey, tt mode) error {
-	updateAccessToken := func(key CacheKey) error {
+func (d *tokenService) updateAndWriteFileToken(key CacheKey, tt mode) error {
+	updateAndWriteFileAccessToken := func(key CacheKey) error {
 		_, err := d.requestTokenToZts(key, mACCESS_TOKEN, "daemon_access_token_update")
-		return err
+		if err != nil || !key.WriteFileRequired {
+			return err
+		}
+		// File output processing
+		domain, role := key.Domain, key.Role
+		token := d.accessTokenCache.Load(key)
+		outPath := filepath.Join(d.tokenDir, domain+":role."+role+".accesstoken")
+		return d.writeFile(token, outPath, mACCESS_TOKEN)
 	}
-	updateRoleToken := func(key CacheKey) error {
+	updateAndWriteFileRoleToken := func(key CacheKey) error {
 		_, err := d.requestTokenToZts(key, mROLE_TOKEN, "daemon_role_token_update")
-		return err
+		if err != nil || !key.WriteFileRequired {
+			return err
+		}
+		// File output processing
+		domain, role := key.Domain, key.Role
+		token := d.roleTokenCache.Load(key)
+		outPath := filepath.Join(d.tokenDir, domain+":role."+role+".roletoken")
+		return d.writeFile(token, outPath, mROLE_TOKEN)
 	}
-
 	switch tt {
 	case mACCESS_TOKEN:
-		return updateAccessToken(key)
+		return updateAndWriteFileAccessToken(key)
 	case mROLE_TOKEN:
-		return updateRoleToken(key)
+		return updateAndWriteFileRoleToken(key)
 	default:
 		return fmt.Errorf("Invalid token type: %d", tt)
 	}
-}
-
-// writeFiles outputs the latest Access Tokens and Role Tokens in the memory cache to files.
-// The tokens to be output are those specified by the TargetDomainRoles for the domain and roles.
-// If multiple tokens are to be output, the file output process will be executed in parallel using go routines.
-func (d *tokenService) writeFiles(ctx context.Context, maxElapsedTime time.Duration) []error {
-	if d.tokenDir == "" {
-		log.Debugf("Skipping to write token files to directory[%s]", d.tokenDir)
-		return nil
-	}
-
-	// Create the directory before saving tokens
-	if err := os.MkdirAll(d.tokenDir, 0755); err != nil {
-		return []error{fmt.Errorf("unable to create directory for tokens: %w", err)}
-	}
-
-	var atErrorCount, rtErrorCount atomic.Int64
-	var wg sync.WaitGroup
-	echan := make(chan error, len(d.atTargetDomainRolesToFile)+len(d.rtTargetDomainRolesToFile))
-
-	for _, k := range d.atTargetDomainRolesToFile {
-		wg.Add(1)
-		go func(k CacheKey) {
-			defer wg.Done()
-			domain, role := k.Domain, k.Role
-			token := d.accessTokenCache.Load(k)
-			outPath := filepath.Join(d.tokenDir, domain+":role."+role+".accesstoken")
-			err := d.writeFileWithRetry(ctx, maxElapsedTime, token, outPath, mACCESS_TOKEN)
-			if err != nil {
-				echan <- err
-				atErrorCount.Add(1)
-			}
-		}(k)
-	}
-
-	for _, k := range d.rtTargetDomainRolesToFile {
-		wg.Add(1)
-		go func(k CacheKey) {
-			defer wg.Done()
-			domain, role := k.Domain, k.Role
-			token := d.roleTokenCache.Load(k)
-			outPath := filepath.Join(d.tokenDir, domain+":role."+role+".roletoken")
-			err := d.writeFileWithRetry(ctx, maxElapsedTime, token, outPath, mROLE_TOKEN)
-			if err != nil {
-				echan <- err
-				rtErrorCount.Add(1)
-			}
-		}(k)
-	}
-
-	// wait for ALL token updates to complete
-	wg.Wait()
-	log.Infof("Saved tokens to files. accesstoken:success[%d],error[%d]; roletoken:success[%d],error[%d]", int64(len(d.atTargetDomainRolesToFile))-atErrorCount.Load(), atErrorCount.Load(), int64(len(d.rtTargetDomainRolesToFile))-rtErrorCount.Load(), rtErrorCount.Load())
-
-	// collect errors
-	close(echan)
-	errs := make([]error, 0, len(d.atTargetDomainRolesToFile)+len(d.rtTargetDomainRolesToFile))
-	for err := range echan {
-		errs = append(errs, err)
-	}
-	return errs
-}
-
-// writeFileWithRetry attempts multiple times to write a file for the given token (AT or RT) by utilizing writeFile()
-func (d *tokenService) writeFileWithRetry(ctx context.Context, maxElapsedTime time.Duration, token Token, outPath string, tt mode) error {
-	operation := func() error {
-		return d.writeFile(token, outPath, tt)
-	}
-	notifyOnErr := func(err error, backoffDelay time.Duration) {
-		log.Errorf("Failed to output the token to a file: %s. Retrying in %s", err.Error(), backoffDelay)
-	}
-	return backoff.RetryNotify(operation, newExponentialBackOff(ctx, maxElapsedTime), notifyOnErr)
 }
 
 // writeFile outputs given token (AT or RT) as file
@@ -530,8 +451,7 @@ func (d *tokenService) writeFile(token Token, outPath string, tt mode) error {
 		return nil
 	}
 
-	log.Infof("[New %s Token] Domain: %s, Role: %s", tokenType, domain, role)
-	log.Debugf("Saving %s Token[%d bytes] at %s", tokenType, len(rawToken), outPath)
+	log.Infof("[Saving %s Token] Domain: %s, Role: %s[%d bytes] in %s", tokenType, domain, role, len(rawToken), outPath)
 	if err := w.AddBytes(outPath, 0644, []byte(rawToken)); err != nil {
 		return fmt.Errorf("unable to save %s Token: %w", tokenType, err)
 	}


### PR DESCRIPTION
# Description
Updated the internal logic of the function that outputs Access Tokens and Role Tokens to files.
The process of updating the memory cache for each token will also include file output processing. This will result in the following:
- File output and retry processing will be performed for each token.
- File output processing will be executed in parallel.

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
