### PR TITLE
Add Path Generator

### DIFF
--- a/pkg/util/path-generator.go
+++ b/pkg/util/path-generator.go
@@ -1,0 +1,53 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+// GeneratePath generates the output path for the credentials by applying the domain name, role name, and delimiter to a specified naming format.
+// i.e) namingFormat=="/var/run/athenz/rolecerts/{{domain}}{{delimiter}}{{role}}"
+func GeneratePath(namingFormat, domain, role, delimiter string) (string, error) {
+	if namingFormat == "" {
+		return "", fmt.Errorf("naming format is empty")
+	}
+	if domain == "" {
+		return "", fmt.Errorf("domain is empty")
+	}
+	// If the role is an empty string, the delimiter used to separate the domain name and the role name is discarded as not necessary
+	// i.e) domain="athenz", role="" => User wants to fetch tokens directly associated to the domain.
+	if role == "" {
+		delimiter = ""
+	}
+	funcMap := template.FuncMap{
+		"domain":    func() string { return domain },
+		"role":      func() string { return role },
+		"delimiter": func() string { return delimiter },
+	}
+
+	generator, err := template.New("pathGenerator").Funcs(funcMap).Parse(namingFormat)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse naming format: %v", err)
+	}
+
+	var writer strings.Builder
+	if err := generator.Execute(&writer, nil); err != nil {
+		return "", fmt.Errorf("failed to generate path: %v", err)
+	}
+	return writer.String(), nil
+}

--- a/pkg/util/path-generator_test.go
+++ b/pkg/util/path-generator_test.go
@@ -1,0 +1,128 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGeneratePath(t *testing.T) {
+	type args struct {
+		namingFormat string
+		domain       string
+		role         string
+		delimiter    string
+	}
+	tests := []struct {
+		testCase string
+		args     args
+		want     string
+		wantErr  string
+	}{
+		{
+			testCase: "return success with valid input",
+			args: args{
+				namingFormat: "/var/run/athenz/rolecerts/{{domain}}{{delimiter}}{{role}}.cert.pem",
+				domain:       "athenz",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "/var/run/athenz/rolecerts/athenz:role.users.cert.pem",
+			wantErr: "",
+		},
+		{
+			testCase: "return success with valid input, duplicate placeholder",
+			args: args{
+				namingFormat: "/var/run/athenz/{{domain}}/{{domain}}{{delimiter}}{{role}}.cert.pem",
+				domain:       "athenz",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "/var/run/athenz/athenz/athenz:role.users.cert.pem",
+			wantErr: "",
+		},
+		{
+			testCase: "return error with empty naming format",
+			args: args{
+				namingFormat: "",
+				domain:       "athenz",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "",
+			wantErr: "naming format is empty",
+		},
+		{
+			testCase: "return error with empty domain",
+			args: args{
+				namingFormat: "/var/run/athenz/rolecerts/{{domain}}{{delimiter}}{{role}}.cert.pem",
+				domain:       "",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "",
+			wantErr: "domain is empty",
+		},
+		{
+			testCase: "return success with empty role, delimiter is discarded",
+			args: args{
+				namingFormat: "/var/run/athenz/rolecerts/{{domain}}{{delimiter}}{{role}}.cert.pem",
+				domain:       "athenz",
+				role:         "",
+				delimiter:    ":role.",
+			},
+			want:    "/var/run/athenz/rolecerts/athenz.cert.pem",
+			wantErr: "",
+		},
+		{
+			testCase: "return error with invalid naming format, missing placeholder",
+			args: args{
+				namingFormat: "{{dummy}}",
+				domain:       "athenz",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "",
+			wantErr: "failed to parse naming format: template: pathGenerator:1: function \"dummy\" not defined",
+		},
+		{
+			testCase: "return success with the placeholder test for {{.}} and {{.dummy}}, when referencing non-existent data, it results in an empty string.",
+			args: args{
+				namingFormat: "/var/run/athenz/rolecerts/{{.}}{{.dummy}}{{domain}}{{delimiter}}{{role}}.cert.pem",
+				domain:       "athenz",
+				role:         "users",
+				delimiter:    ":role.",
+			},
+			want:    "/var/run/athenz/rolecerts/athenz:role.users.cert.pem",
+			wantErr: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			got, err := GeneratePath(test.args.namingFormat, test.args.domain, test.args.role, test.args.delimiter)
+			fmt.Println(got, err)
+			if got != test.want {
+				t.Errorf("GeneratePath() got = %v, want %v", got, test.want)
+			}
+			if err != nil || test.wantErr != "" {
+				if err == nil || (test.wantErr != err.Error()) {
+					t.Errorf("GeneratePath() err = %v, wantErr %v", err, test.wantErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
To address https://github.com/AthenZ/k8s-athenz-sia/issues/49, we created a module that outputs customizable file names (with directories) for RoleCert, AccessTokens and RoleTokens. The module is not yet used but will be integrated in the next pull request. The actual environment configurations will be also included in future PRs later.

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
