### PR TITLE
Fix Derived RoleCert Dir

### DIFF
--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -48,7 +48,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	// Enabled from now on:
 	idCfg.RoleCert = DerivedRoleCert{
 		Use:               true,
-		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/",
+		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/", // making sure it always ends with `/`
 		TargetDomainRoles: targetDomainRoles,
 		Delimiter:         idCfg.roleCertFilenameDelimiter,
 		UseKeyFileOutput:  idCfg.roleCertKeyFileOutput,

--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -16,6 +16,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
 )
 
@@ -46,7 +48,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	// Enabled from now on:
 	idCfg.RoleCert = DerivedRoleCert{
 		Use:               true,
-		Dir:               idCfg.roleCertDir,
+		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/",
 		TargetDomainRoles: targetDomainRoles,
 		Delimiter:         idCfg.roleCertFilenameDelimiter,
 		UseKeyFileOutput:  idCfg.roleCertKeyFileOutput,


### PR DESCRIPTION
# Description
Fixed an issue where specifying a path without a trailing slash (e.g., '/var/run/athenz') in ROLECERT_DIR would result in the directory not being created correctly.

This was introduced in: https://github.com/AthenZ/k8s-athenz-sia/pull/142

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
