### PR TITLE
Refactor parseTargetDomainRoles with derived state `DerivedRoleCert`

### DIFF
--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -34,7 +34,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	// default:
 	idCfg.RoleCert.Use = false
 
-	if len(idCfg.TargetDomainRoles.RoleCerts) == 0 {
+	if len(idCfg.targetDomainRoles.RoleCerts) == 0 {
 		return nil // disabled
 	}
 
@@ -46,7 +46,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	idCfg.RoleCert = DerivedRoleCert{
 		Use:               true,
 		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/", // making sure it always ends with `/`
-		TargetDomainRoles: idCfg.TargetDomainRoles.RoleCerts,
+		TargetDomainRoles: idCfg.targetDomainRoles.RoleCerts,
 		Delimiter:         idCfg.roleCertFilenameDelimiter,
 		UseKeyFileOutput:  idCfg.roleCertKeyFileOutput,
 	}

--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -34,10 +34,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	// default:
 	idCfg.RoleCert.Use = false
 
-	// handle role certificates' derived state:
-	targetDomainRoles, _ := parseTargetDomainRoles(idCfg.rawTargetDomainRoles)
-
-	if len(targetDomainRoles) == 0 {
+	if len(idCfg.TargetDomainRoles.RoleCerts) == 0 {
 		return nil // disabled
 	}
 
@@ -49,7 +46,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	idCfg.RoleCert = DerivedRoleCert{
 		Use:               true,
 		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/", // making sure it always ends with `/`
-		TargetDomainRoles: targetDomainRoles,
+		TargetDomainRoles: idCfg.TargetDomainRoles.RoleCerts,
 		Delimiter:         idCfg.roleCertFilenameDelimiter,
 		UseKeyFileOutput:  idCfg.roleCertKeyFileOutput,
 	}

--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -34,7 +34,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	// default:
 	idCfg.RoleCert.Use = false
 
-	if len(idCfg.targetDomainRoles.RoleCerts) == 0 {
+	if len(idCfg.targetDomainRoles.roleCerts) == 0 {
 		return nil // disabled
 	}
 
@@ -46,7 +46,7 @@ func (idCfg *IdentityConfig) derivedRoleCertConfig() error {
 	idCfg.RoleCert = DerivedRoleCert{
 		Use:               true,
 		Dir:               strings.TrimSuffix(idCfg.roleCertDir, "/") + "/", // making sure it always ends with `/`
-		TargetDomainRoles: idCfg.targetDomainRoles.RoleCerts,
+		TargetDomainRoles: idCfg.targetDomainRoles.roleCerts,
 		Delimiter:         idCfg.roleCertFilenameDelimiter,
 		UseKeyFileOutput:  idCfg.roleCertKeyFileOutput,
 	}

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -27,12 +27,11 @@ type DerivedTargetDomainRoles struct {
 	// Tokens    []DomainRole
 }
 
-// derivedTargetDomainRoles sets the DerivedTargetDomainRoles with given rawTargetDomainRoles.
-// rawTargetDomainRoles is a simple string, and therefore it is separated by commas.
-// If the input string does not contain ":role",
-// the entire string is considered as the Athenz Domain and the Athenz Role is set to an empty string.
-// If the input string does contain ":role",
-// the string is split into two parts: the Athenz Domain and the Athenz Role.
+// derivedTargetDomainRoles sets the DerivedTargetDomainRoles with the given rawTargetDomainRoles.
+// rawTargetDomainRoles is a comma-separated string of targetDomainRoles.
+// Each targetDomainRole may or may not contain the delimiter ":role".
+// If a targetDomainRole does not contain ":role", the entire string is considered as the Athenz Domain, and the Athenz Role is set to an empty string.
+// If a targetDomainRole contains ":role", the string is split into two parts: the Athenz Domain and the Athenz Role.
 func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 	elements := strings.Split(idCfg.rawTargetDomainRoles, ",") // TODO: Rename me to targetDomainRoles (OR, drs)
 	roleCertDomainRoles := make([]DomainRole, 0, len(elements))

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -33,6 +33,11 @@ type DerivedTargetDomainRoles struct {
 // If a targetDomainRole does not contain ":role", the entire string is considered as the Athenz Domain, and the Athenz Role is set to an empty string.
 // If a targetDomainRole contains ":role", the string is split into two parts: the Athenz Domain and the Athenz Role.
 func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
+	// TODO: Maybe use trim() here, so that empty strings are not considered as valid targetDomainRoles:
+	if idCfg.rawTargetDomainRoles == "" {
+		return nil
+	}
+
 	elements := strings.Split(idCfg.rawTargetDomainRoles, ",") // TODO: Rename me to targetDomainRoles (OR, drs)
 	roleCertDomainRoles := make([]DomainRole, 0, len(elements))
 	tokenDomainRoles := make([]DomainRole, 0, len(elements))

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -45,7 +45,6 @@ func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 	for _, domainRole := range elements {
 		targetDomain, targetRole, err := athenz.SplitRoleName(domainRole)
 
-		// The entire specified string is considered as the domain name, and no role is specified:
 		if err == nil {
 			// TargetDomainRoles for RoleCert will only be applicable if both the domain and role are set:
 			roleCertDomainRoles = append(roleCertDomainRoles, DomainRole{
@@ -53,6 +52,7 @@ func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 				Role:   targetRole,
 			})
 		} else {
+			// The entire specified string is considered as the domain name, and no role is specified:
 			targetDomain = domainRole
 			targetRole = ""
 			log.Debugf("TARGET_DOMAIN_ROLES[%s] does not contain ':role', so it will be treated as a domain name.", domainRole)

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -34,13 +34,12 @@ type DerivedTargetDomainRoles struct {
 // If the input string does contain ":role",
 // the string is split into two parts: the Athenz Domain and the Athenz Role.
 func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
-	drs := strings.Split(idCfg.rawTargetDomainRoles, ",") // drs=domainRoles
+	elements := strings.Split(idCfg.rawTargetDomainRoles, ",") // TODO: Rename me to targetDomainRoles (OR, drs)
+	roleCertDomainRoles := make([]DomainRole, 0, len(elements))
+	tokenDomainRoles := make([]DomainRole, 0, len(elements))
 
-	roleCertDomainRoles := make([]DomainRole, 0, len(drs))
-	tokenDomainRoles := make([]DomainRole, 0, len(drs))
-
-	for _, dr := range drs {
-		targetDomain, targetRole, err := athenz.SplitRoleName(dr)
+	for _, domainRole := range elements {
+		targetDomain, targetRole, err := athenz.SplitRoleName(domainRole)
 
 		// The entire specified string is considered as the domain name, and no role is specified:
 		if err == nil {
@@ -50,9 +49,9 @@ func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 				Role:   targetRole,
 			})
 		} else {
-			targetDomain = dr
+			targetDomain = domainRole
 			targetRole = ""
-			log.Debugf("TARGET_DOMAIN_ROLES[%s] does not contain ':role', so it will be treated as a domain name.", dr)
+			log.Debugf("TARGET_DOMAIN_ROLES[%s] does not contain ':role', so it will be treated as a domain name.", domainRole)
 		}
 		tokenDomainRoles = append(tokenDomainRoles, DomainRole{
 			Domain: targetDomain,

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -1,0 +1,70 @@
+// Copyright 2023 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
+package config
+
+import (
+	"strings"
+
+	athenz "github.com/AthenZ/athenz/libs/go/sia/util"
+	"github.com/AthenZ/k8s-athenz-sia/v3/third_party/log"
+)
+
+type DerivedTargetDomainRoles struct {
+	RoleCerts []DomainRole
+	// Tokens    []DomainRole
+}
+
+// derivedTargetDomainRoles first reads given target-domain-roles in raw type,
+// and it parses into DomainRole type, and insert into derived state of fetching role certificates related configuration.
+// each targetDomainRole is separated by commas.
+// If the input string does not contain ":role",
+// the entire string is considered as the domain and the role is set to an empty string.
+// All successfully split pairs are stored in the domainRoles slice.
+func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
+	drs := strings.Split(idCfg.rawTargetDomainRoles, ",") // drs=domainRoles
+
+	roleCertDomainRoles := make([]DomainRole, 0, len(drs))
+	tokenDomainRoles := make([]DomainRole, 0, len(drs))
+
+	for _, dr := range drs {
+		targetDomain, targetRole, err := athenz.SplitRoleName(dr)
+
+		// The entire specified string is considered as the domain name, and no role is specified:
+		if err == nil {
+			// TargetDomainRoles for RoleCert will only be applicable if both the domain and role are set:
+			roleCertDomainRoles = append(roleCertDomainRoles, DomainRole{
+				Domain: targetDomain,
+				Role:   targetRole,
+			})
+		} else {
+			targetDomain = dr
+			targetRole = ""
+			log.Debugf("TARGET_DOMAIN_ROLES[%s] does not contain ':role', so it will be treated as a domain name.", dr)
+		}
+		tokenDomainRoles = append(tokenDomainRoles, DomainRole{
+			Domain: targetDomain,
+			Role:   targetRole,
+		})
+	}
+
+	idCfg.TokenTargetDomainRoles = tokenDomainRoles // TODO: Delete me and refactor by using the type DerivedTargetDomainRoles below:
+	idCfg.TargetDomainRoles = DerivedTargetDomainRoles{
+		RoleCerts: roleCertDomainRoles,
+		// Tokens: tokenDomainRoles,
+	}
+
+	return nil
+}

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -59,7 +59,7 @@ func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 	}
 
 	idCfg.TokenTargetDomainRoles = tokenDomainRoles // TODO: Delete me and refactor by using the type DerivedTargetDomainRoles below:
-	idCfg.TargetDomainRoles = DerivedTargetDomainRoles{
+	idCfg.targetDomainRoles = DerivedTargetDomainRoles{
 		RoleCerts: roleCertDomainRoles,
 		// Tokens: tokenDomainRoles,
 	}

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -23,8 +23,8 @@ import (
 )
 
 type DerivedTargetDomainRoles struct {
-	RoleCerts []DomainRole
-	// Tokens    []DomainRole
+	roleCerts []DomainRole // private as the derived state is used only within the config package
+	// tokens    []DomainRole // private as the derived state is used only within the config package
 }
 
 // derivedTargetDomainRoles sets the DerivedTargetDomainRoles with the given rawTargetDomainRoles.
@@ -60,8 +60,8 @@ func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 
 	idCfg.TokenTargetDomainRoles = tokenDomainRoles // TODO: Delete me and refactor by using the type DerivedTargetDomainRoles below:
 	idCfg.targetDomainRoles = DerivedTargetDomainRoles{
-		RoleCerts: roleCertDomainRoles,
-		// Tokens: tokenDomainRoles,
+		roleCerts: roleCertDomainRoles,
+		// tokens: tokenDomainRoles,
 	}
 
 	return nil

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -27,12 +27,12 @@ type DerivedTargetDomainRoles struct {
 	// Tokens    []DomainRole
 }
 
-// derivedTargetDomainRoles first reads given target-domain-roles in raw type,
-// and it parses into DomainRole type, and insert into derived state of fetching role certificates related configuration.
-// each targetDomainRole is separated by commas.
+// derivedTargetDomainRoles sets the DerivedTargetDomainRoles with given rawTargetDomainRoles.
+// rawTargetDomainRoles is a simple string, and therefore it is separated by commas.
 // If the input string does not contain ":role",
-// the entire string is considered as the domain and the role is set to an empty string.
-// All successfully split pairs are stored in the domainRoles slice.
+// the entire string is considered as the Athenz Domain and the Athenz Role is set to an empty string.
+// If the input string does contain ":role",
+// the string is split into two parts: the Athenz Domain and the Athenz Role.
 func (idCfg *IdentityConfig) derivedTargetDomainRoles() error {
 	drs := strings.Split(idCfg.rawTargetDomainRoles, ",") // drs=domainRoles
 

--- a/pkg/config/dervied.go
+++ b/pkg/config/dervied.go
@@ -16,27 +16,33 @@
 package config
 
 // loadDerivedConfig loads functions from files with prefix "derived-" under /pkg/config
+// The order matters, and the earlier function may affect the later function. Unconsidered change may cause unexpected behavior.
 func (idCfg *IdentityConfig) loadDerivedConfig() error {
 	// TODO:
 	// if err := idCfg.derivedServiceCert(); err != nil {
 	// 	return err
 	// }
 
-	// TODO:
-	// if err := idCfg.derivedTargetDomainRoles(); err != nil {
-	// 	return err
-	// }
+	if err := idCfg.derivedTargetDomainRoles(); err != nil {
+		return err
+	}
 
+	// depends on the following:
+	// - derivedTargetDomainRoles()
 	if err := idCfg.derivedRoleCertConfig(); err != nil {
 		return err
 	}
 
 	// TODO:
+	// depends on the following:
+	// - derivedTargetDomainRoles()
 	// if err := idCfg.derivedAccessTokenConfig(); err != nil {
 	// 	return err
 	// }
 
 	// TODO:
+	// depends on the following:
+	// - derivedTargetDomainRoles()
 	// if err := idCfg.derivedRoleTokenConfig(); err != nil {
 	// 	return err
 	// }

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -47,7 +47,7 @@ type IdentityConfig struct {
 	PodName                string
 	Reloader               *util.CertReloader
 	ServerCACert           string
-	TokenTargetDomainRoles []DomainRole
+	TokenTargetDomainRoles []DomainRole // TODO: Will be migrated into DerivedTargetDomainRoles
 	TargetDomainRoles      DerivedTargetDomainRoles
 	// RoleCerts Derived State and its related fields:
 	RoleCert                  DerivedRoleCert

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -48,6 +48,7 @@ type IdentityConfig struct {
 	Reloader               *util.CertReloader
 	ServerCACert           string
 	TokenTargetDomainRoles []DomainRole
+	TargetDomainRoles      DerivedTargetDomainRoles
 	// RoleCerts Derived State and its related fields:
 	RoleCert                  DerivedRoleCert
 	roleCertDir               string

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -47,8 +47,8 @@ type IdentityConfig struct {
 	PodName                string
 	Reloader               *util.CertReloader
 	ServerCACert           string
-	TokenTargetDomainRoles []DomainRole // TODO: Will be migrated into DerivedTargetDomainRoles
-	TargetDomainRoles      DerivedTargetDomainRoles
+	TokenTargetDomainRoles []DomainRole             // TODO: Will be migrated into DerivedTargetDomainRoles
+	targetDomainRoles      DerivedTargetDomainRoles // private as the derived state is used only within the config package
 	// RoleCerts Derived State and its related fields:
 	RoleCert                  DerivedRoleCert
 	roleCertDir               string


### PR DESCRIPTION
# Description
The current code has function `parseTargetDomainRoles` out of nowhere.
Refactor with derived state for easier read.

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
