### PR TITLE
Refactor derived-token-file with `Format`

### DIFF
--- a/pkg/config/derived-token-file.go
+++ b/pkg/config/derived-token-file.go
@@ -16,18 +16,18 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 )
 
 type TokenFileConfig struct {
-	Use bool
-	// TODO: Add Format
-	// Format    string
+	Use       bool
+	Format    string
 	Delimiter string
 }
 
 type DerivedTokenFile struct {
-	Dir         string
+	Dir         string // TODO: This might be deleted later
 	AccessToken TokenFileConfig
 	RoleToken   TokenFileConfig
 }
@@ -38,13 +38,13 @@ func (idCfg *IdentityConfig) derivedTokenFileConfig() error {
 	idCfg.TokenFile = DerivedTokenFile{
 		Dir: "",
 		AccessToken: TokenFileConfig{
-			Use: false,
-			// Format:    "",
+			Use:       false,
+			Format:    "",
 			Delimiter: "",
 		},
 		RoleToken: TokenFileConfig{
-			Use: false,
-			// Format:    "",
+			Use:       false,
+			Format:    "",
 			Delimiter: "",
 		},
 	}
@@ -62,14 +62,14 @@ func (idCfg *IdentityConfig) derivedTokenFileConfig() error {
 			// disabled
 			if !strings.Contains(idCfg.TokenType, "accesstoken") {
 				return TokenFileConfig{
-					Use: false,
-					// Format:    "",
+					Use:       false,
+					Format:    "",
 					Delimiter: "",
 				}
 			}
 			return TokenFileConfig{
-				Use: true,
-				// Format:    filepath.Join(idCfg.TokenDir, "{{domain}}{{delimiter}}{{role}}.accesstoken"),
+				Use:       true,
+				Format:    filepath.Join(idCfg.tokenDir, "{{domain}}{{delimiter}}{{role}}.accesstoken"),
 				Delimiter: ":role.",
 			}
 
@@ -78,14 +78,14 @@ func (idCfg *IdentityConfig) derivedTokenFileConfig() error {
 			// disabled
 			if !strings.Contains(idCfg.TokenType, "roletoken") {
 				return TokenFileConfig{
-					Use: false,
-					// Format:    "",
+					Use:       false,
+					Format:    "",
 					Delimiter: "",
 				}
 			}
 			return TokenFileConfig{
-				Use: true,
-				// Format:    filepath.Join(idCfg.TokenDir, "{{domain}}{{delimiter}}{{role}}.roletoken"),
+				Use:       true,
+				Format:    filepath.Join(idCfg.tokenDir, "{{domain}}{{delimiter}}{{role}}.roletoken"),
 				Delimiter: ":role.",
 			}
 		}(),

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"runtime/metrics"
 	"sync"
 	"sync/atomic"
@@ -399,7 +398,10 @@ func (d *tokenService) updateAndWriteFileToken(key CacheKey, tt mode) error {
 		// File output processing
 		domain, role := key.Domain, key.Role
 		token := d.accessTokenCache.Load(key)
-		outPath := filepath.Join(d.idCfg.TokenFile.Dir, domain+d.idCfg.TokenFile.AccessToken.Delimiter+role+".accesstoken")
+		outPath, err := extutil.GeneratePath(d.idCfg.TokenFile.AccessToken.Format, domain, role, d.idCfg.TokenFile.AccessToken.Delimiter)
+		if err != nil {
+			return fmt.Errorf("failed to generate path for access token with format [%s], domain [%s], role [%s], delimiter [%s]: %w", d.idCfg.TokenFile.AccessToken.Format, domain, role, d.idCfg.TokenFile.AccessToken.Delimiter, err)
+		}
 		return d.writeFile(token, outPath, mACCESS_TOKEN)
 	}
 	updateAndWriteFileRoleToken := func(key CacheKey) error {
@@ -410,7 +412,11 @@ func (d *tokenService) updateAndWriteFileToken(key CacheKey, tt mode) error {
 		// File output processing
 		domain, role := key.Domain, key.Role
 		token := d.roleTokenCache.Load(key)
-		outPath := filepath.Join(d.idCfg.TokenFile.Dir, domain+d.idCfg.TokenFile.RoleToken.Delimiter+role+".roletoken")
+		outPath, err := extutil.GeneratePath(d.idCfg.TokenFile.RoleToken.Format, domain, role, d.idCfg.TokenFile.RoleToken.Delimiter)
+		if err != nil {
+			return fmt.Errorf("failed to generate path for role token with format [%s], domain [%s], role [%s], delimiter [%s]: %w", d.idCfg.TokenFile.RoleToken.Format, domain, role, d.idCfg.TokenFile.RoleToken.Delimiter, err)
+		}
+
 		return d.writeFile(token, outPath, mROLE_TOKEN)
 	}
 	switch tt {


### PR DESCRIPTION
# Description
Refactored derivedTokenFIleConfig() to utilize the function GeneratePath() introduced in https://github.com/AthenZ/k8s-athenz-sia/pull/141
Also has added some comments for TODOs

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
