### PR TITLE
remove access info log

### DIFF
--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -315,8 +315,10 @@ func newHandlerFunc(ts *tokenService, timeout time.Duration) http.Handler {
 		io.WriteString(w, string(response))
 	}
 
-	// logging && timeout handler
-	return withLogging(http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout"))
+	// timeout handler
+	return http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout")
+	// TODO: After reconsidering the output specifications of the access log, delete or modify the following code and related methods.
+	// return withLogging(http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout"))
 }
 
 // contextKey is used to create context key to avoid collision

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -315,7 +315,7 @@ func newHandlerFunc(ts *tokenService, timeout time.Duration) http.Handler {
 		io.WriteString(w, string(response))
 	}
 
-	// timeout handler
+	// logging && timeout handler
 	return withLogging(http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout"))
 }
 

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -316,9 +316,7 @@ func newHandlerFunc(ts *tokenService, timeout time.Duration) http.Handler {
 	}
 
 	// timeout handler
-	return http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout")
-	// TODO: After reconsidering the output specifications of the access log, delete or modify the following code and related methods.
-	// return withLogging(http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout"))
+	return withLogging(http.TimeoutHandler(http.HandlerFunc(mainHandler), timeout, "Handler timeout by token-server-timeout"))
 }
 
 // contextKey is used to create context key to avoid collision
@@ -329,21 +327,25 @@ type contextKey struct {
 var contextKeyRequestID = &contextKey{"requestID"}
 
 // withLogging wraps handler with logging and request ID injection
+// TODO: Outputting access logs at the INFO level can result in a massive amount of logs for users with high RPS, potentially causing issues.
+// Therefore, we are temporarily modifying the system to not output INFO logs.
+// In the future, we need to reconsider the logging policy for these logs.
 func withLogging(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := uuid.New().String()
 		ctx := context.WithValue(r.Context(), contextKeyRequestID, requestID)
 
-		startTime := time.Now()
-		log.Infof("Received request: method[%s], endpoint[%s], remoteAddr[%s] requestID[%s]", r.Method, r.RequestURI, r.RemoteAddr, requestID)
+		// startTime := time.Now()
+		// log.Infof("Received request: method[%s], endpoint[%s], remoteAddr[%s] requestID[%s]", r.Method, r.RequestURI, r.RemoteAddr, requestID)
 
 		// wrap ResponseWriter to cache status code
 		wrappedWriter := newLoggingResponseWriter(w)
 		handler.ServeHTTP(wrappedWriter, r.WithContext(ctx))
 
-		latency := time.Since(startTime)
-		statusCode := wrappedWriter.statusCode
-		log.Infof("Response sent: statusCode[%d], latency[%s], requestID[%s]", statusCode, latency, requestID)
+		// TODO: Since this variable is used only once, would it be better to use it directly?
+		// latency := time.Since(startTime)
+		// statusCode := wrappedWriter.statusCode
+		// log.Infof("Response sent: statusCode[%d], latency[%s], requestID[%s]", statusCode, latency, requestID)
 	})
 }
 


### PR DESCRIPTION
# Description
Modify the system to temporarily not output INFO logs for each Token retrieval request from clients. 
- For clients with a high number of requests, the volume of logs can become enormous, potentially affecting performance and log collection.

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
