### PR TITLE
prevent race condition in http.Server.TLSConfig and deadlock in shutdown

### DIFF
--- a/pkg/healthcheck/service.go
+++ b/pkg/healthcheck/service.go
@@ -98,12 +98,11 @@ func (hs *hcService) Shutdown() {
 	log.Info("Initiating shutdown of health check daemon ...")
 	close(hs.shutdownChan)
 
-	if hs.hcServer != nil && hs.hcServerRunning {
+	if hs.hcServer != nil {
 		forcedCtx, cancel := context.WithCancel(context.Background())
 		cancel() // force shutdown health check server without delay
 		hs.hcServer.SetKeepAlivesEnabled(false)
-		err := hs.hcServer.Shutdown(forcedCtx)
-		if err != nil && err != context.Canceled {
+		if err := hs.hcServer.Shutdown(forcedCtx); err != nil && err != context.Canceled {
 			log.Errorf("Failed to shutdown health check server: %s", err.Error())
 		}
 	}

--- a/pkg/healthcheck/service.go
+++ b/pkg/healthcheck/service.go
@@ -99,6 +99,8 @@ func (hs *hcService) Shutdown() {
 	close(hs.shutdownChan)
 
 	if hs.hcServer != nil {
+		// As hs.hcServer should always shutdown forcefully, NO need to check hs.hcServerRunning == true
+
 		forcedCtx, cancel := context.WithCancel(context.Background())
 		cancel() // force shutdown health check server without delay
 		hs.hcServer.SetKeepAlivesEnabled(false)
@@ -107,7 +109,7 @@ func (hs *hcService) Shutdown() {
 		}
 	}
 
-	// wait for graceful shutdown
+	// wait for forceful shutdown
 	hs.shutdownWg.Wait()
 }
 

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -133,7 +133,7 @@ func (ms *metricsService) Shutdown() {
 	log.Info("Initiating shutdown of metrics exporter daemon ...")
 	close(ms.shutdownChan)
 
-	if ms.exporter != nil && ms.exporterRunning {
+	if ms.exporter != nil {
 		err := ms.exporter.Shutdown() // context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
 		// P.S. Make sure to use the httpChecker to ensure ListenAndServe() is finished before Shutdown() is called. If ListenAndServe() does not finish creating the server object before Shutdown() is called, the internal server field will be nil and Shutdown() be a no-op. ListenAndServe() will block and cause deadlock.
 		if err != nil {

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -68,10 +68,16 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		ListenAddress: idCfg.MetricsServerAddr,
 		SystemdSocket: false,
 		ConfigFile:    "",
-		Files: []string{
-			idCfg.CertFile,
-			idCfg.CaCertFile,
-		},
+		Files: func() []string {
+			files := []string{}
+			if idCfg.CertFile != "" {
+				files = append(files, idCfg.CertFile)
+			}
+			if idCfg.CaCertFile != "" {
+				files = append(files, idCfg.CaCertFile)
+			}
+			return files
+		}(),
 		Directories:           []string{},
 		YAMLs:                 []string{},
 		TrimPathComponents:    0,

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -134,7 +134,10 @@ func (ms *metricsService) Shutdown() {
 	close(ms.shutdownChan)
 
 	if ms.exporter != nil {
-		err := ms.exporter.Shutdown() // context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
+		// As ms.exporter.Shutdown() can ONLY shutdown gracefully, NO need to check ms.exporterRunning == true
+
+		err := ms.exporter.Shutdown()
+		// context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
 		// P.S. Make sure to use the httpChecker to ensure ListenAndServe() is finished before Shutdown() is called. If ListenAndServe() does not finish creating the server object before Shutdown() is called, the internal server field will be nil and Shutdown() be a no-op. ListenAndServe() will block and cause deadlock.
 		if err != nil {
 			log.Errorf("Failed to shutdown metrics exporter server: %s", err.Error())

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -190,8 +190,6 @@ func (ts *tokenService) Start(ctx context.Context) error {
 			log.Info("Stopped token provider server")
 		}()
 
-		log.Warnln("🚨🚨🚨 Sleep 1s to trigger race condition of TLSConfig... 🚨🚨🚨")
-		time.Sleep(time.Second)
 		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS.Use); err != nil {
 			log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
 			return err

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -190,6 +190,8 @@ func (ts *tokenService) Start(ctx context.Context) error {
 			log.Info("Stopped token provider server")
 		}()
 
+		log.Warnln("🚨🚨🚨 Sleep 1s to trigger race condition of TLSConfig... 🚨🚨🚨")
+		time.Sleep(time.Second)
 		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS.Use); err != nil {
 			log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
 			return err

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -257,20 +257,32 @@ func (ts *tokenService) Shutdown() {
 	log.Info("Initiating shutdown of token provider daemon ...")
 	close(ts.shutdownChan)
 
-	if ts.tokenServer != nil && ts.tokenServerRunning {
-		log.Infof("Delaying token provider server shutdown for %s to shutdown gracefully ...", ts.idCfg.TokenServer.ShutdownDelay.String())
-		time.Sleep(ts.idCfg.TokenServer.ShutdownDelay)
+	if ts.tokenServer != nil {
+		if ts.tokenServerRunning {
+			log.Infof("Delaying token provider server shutdown for %s to shutdown gracefully ...", ts.idCfg.TokenServer.ShutdownDelay.String())
+			time.Sleep(ts.idCfg.TokenServer.ShutdownDelay)
 
-		ctx, cancel := context.WithTimeout(context.Background(), ts.idCfg.TokenServer.ShutdownTimeout)
-		defer cancel()
-		ts.tokenServer.SetKeepAlivesEnabled(false)
-		if err := ts.tokenServer.Shutdown(ctx); err != nil {
-			// graceful shutdown error or timeout should be fatal
-			log.Errorf("Failed to shutdown token provider server: %s", err.Error())
+			ctx, cancel := context.WithTimeout(context.Background(), ts.idCfg.TokenServer.ShutdownTimeout)
+			defer cancel()
+			ts.tokenServer.SetKeepAlivesEnabled(false)
+			if err := ts.tokenServer.Shutdown(ctx); err != nil {
+				// graceful shutdown error or timeout should be fatal
+				log.Errorf("Failed to shutdown token provider server gracefully: %s", err.Error())
+			}
+		} else {
+			log.Info("Force shutdown token provider server...")
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			ts.tokenServer.SetKeepAlivesEnabled(false)
+			if err := ts.tokenServer.Shutdown(ctx); err != nil && err != context.Canceled {
+				// forceful shutdown error
+				log.Errorf("Failed to shutdown token provider server forcefully: %s", err.Error())
+			}
 		}
 	}
 
-	// wait for graceful shutdown
+	// wait for graceful/forceful shutdown
 	ts.shutdownWg.Wait()
 }
 

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -190,7 +190,7 @@ func (ts *tokenService) Start(ctx context.Context) error {
 			log.Info("Stopped token provider server")
 		}()
 
-		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.tokenServer.TLSConfig != nil); err != nil {
+		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS.Use); err != nil {
 			log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
 			return err
 		}

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -272,10 +272,10 @@ func (ts *tokenService) Shutdown() {
 		} else {
 			log.Info("Force shutdown token provider server...")
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
+			forcedCtx, cancel := context.WithCancel(context.Background())
+			cancel() // force shutdown token provider server without delay
 			ts.tokenServer.SetKeepAlivesEnabled(false)
-			if err := ts.tokenServer.Shutdown(ctx); err != nil && err != context.Canceled {
+			if err := ts.tokenServer.Shutdown(forcedCtx); err != nil && err != context.Canceled {
 				// forceful shutdown error
 				log.Errorf("Failed to shutdown token provider server forcefully: %s", err.Error())
 			}


### PR DESCRIPTION
# Description

Fix of the following error. There are 2 issues causing the problem which are listed as below.

```log
WARNING[2024-11-28T18:09:07+09:00] Failed to confirm the server ready with GET request: Get "https://localhost:22408/": http: server gave HTTP response to HTTPS client. Retrying in 44.115047941s
ERROR[2024-11-28T18:09:52+09:00] Failed to confirm token provider server ready: Get "https://localhost:22408/": http: server gave HTTP response to HTTPS client
ERROR[2024-11-28T18:09:52+09:00] Error starting token provider: Get "https://localhost:22408/": http: server gave HTTP response to HTTPS client

...

INFO[2024-11-28T18:09:52+09:00] Initiating shutdown by cause: start failed: Get "https://localhost:22408/": http: server gave HTTP response to HTTPS client ...
INFO[2024-11-28T18:09:52+09:00] Initiating shutdown of health check daemon ...
INFO[2024-11-28T18:09:52+09:00] Initiating shutdown of metrics exporter daemon ...
INFO[2024-11-28T18:09:52+09:00] Initiating shutdown of token provider daemon ...

... process still running
```

### Issue 1 - race condition

As `http.Server.ListenAndServe` will write to `http.Server.TLSConfig` internally, there is a race condition when using `http.Server.TLSConfig` in the if-statement.

```
ERROR[2024-11-28T18:09:52+09:00] Failed to confirm token provider server ready: Get "https://localhost:22408/": http: server gave HTTP response to HTTPS client
```

✅ expected execution order:
1. `ts.tokenServer.TLSConfig != nil` => evaluate to `false`
1. `ts.tokenServer.ListenAndServe()` => set `TLSConfig` to `non-nil` value

❌ unexpected/problematic execution order:
1. `ts.tokenServer.ListenAndServe()` => set `TLSConfig` to `non-nil` value
1. `ts.tokenServer.TLSConfig != nil` => evaluate to `true`
1. causing the `http: server gave HTTP response to HTTPS client error`

### Details 1

#### tracestack
https://go.googlesource.com/go/+/refs/tags/go1.21.13/src/net/http/server.go
`ListenAndServe()` => `Serve()` => `setupHTTP2_Serve()` => `onceSetNextProtoDefaults_Serve()` => `onceSetNextProtoDefaults()` => `http2ConfigureServer()`

https://go.googlesource.com/go/+/refs/tags/go1.23.3/src/net/http/h2_bundle.go#4129
`http2ConfigureServer()`
```go
	if s.TLSConfig == nil {
		s.TLSConfig = new(tls.Config)
	}
```

### Issue 2 - shutdown deadlock

The current shutdown logic misses server startup timeout error handling (i.e. `ts.tokenServerRunning == false`) causing the shutdown function to wait indefinitely.
https://github.com/AthenZ/k8s-athenz-sia/blob/c477bdccff11e76058695e2282bb6f178f4e5e00/pkg/token/service.go#L260-L274

```log
...
INFO[2024-11-28T18:09:52+09:00] Initiating shutdown of token provider daemon ...

... process still running
```

### Details 2

```go
	// when server startup timeout error、tokenServerRunning == false
	if ts.tokenServer != nil && ts.tokenServerRunning {
		...
		// NO logic to handle tokenServerRunning == false case and release resources
	}

	...
	ts.shutdownWg.Wait() <-- deadlock here
```

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation

## Checklist for maintainer

```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```