### PR TITLE
Fixing a bug where the token server startup check fails when mTLS is enabled

### DIFF
--- a/pkg/daemon/httpchecker.go
+++ b/pkg/daemon/httpchecker.go
@@ -16,7 +16,10 @@ package daemon
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/AthenZ/k8s-athenz-sia/v3/pkg/config"
@@ -24,21 +27,7 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-// WaitForServerReady waits until the HTTP(S) server can respond to a GET request. Should NOT allow cancelling the retry as shuting down non-ready server may cause deadlock.
-func WaitForServerReady(serverAddr string, insecureSkipVerify bool) error {
-
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.TLSClientConfig = &tls.Config{}
-	client := &http.Client{Transport: t}
-
-	var url string
-	if insecureSkipVerify {
-		t.TLSClientConfig.InsecureSkipVerify = true
-		url = "https://" + serverAddr
-	} else {
-		url = "http://" + serverAddr
-	}
-
+func serverRequest(client *http.Client, url string) error {
 	get := func() error {
 		resp, err := client.Get(url)
 		if err == nil {
@@ -60,4 +49,61 @@ func WaitForServerReady(serverAddr string, insecureSkipVerify bool) error {
 	return backoff.RetryNotify(get, getExponentialBackoff(), func(err error, backoffDelay time.Duration) {
 		log.Warnf("Failed to confirm the server ready with GET request: %s. Retrying in %s", err.Error(), backoffDelay)
 	})
+}
+
+// WaitForServerReady waits until the HTTP server can respond to a GET request. Should NOT allow cancelling the retry as shuting down non-ready server may cause deadlock.
+func WaitForServerReady(serverAddr string) error {
+
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	client := &http.Client{Transport: t}
+
+	url := "http://" + serverAddr
+
+	return serverRequest(client, url)
+}
+
+// WaitForServerReady waits until the HTTPS server can respond to a GET request. Should NOT allow cancelling the retry as shuting down non-ready server may cause deadlock.
+func WaitForServerReadyWithTLS(serverAddr string, tlsConfig config.TLS) error {
+	if !tlsConfig.Use {
+		return fmt.Errorf("The server attempted to perform a server check using HTTPS even though TLS was disabled.")
+	}
+
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = &tls.Config{}
+	t.TLSClientConfig.InsecureSkipVerify = true
+
+	if tlsConfig.CAPath != "" {
+		crt, err := tls.LoadX509KeyPair(tlsConfig.CertPath, tlsConfig.KeyPath)
+		if err != nil {
+			return fmt.Errorf("Cannot load X509 key pair cert [%q], key [%q]: %w", tlsConfig.CertPath, tlsConfig.KeyPath, err)
+		}
+		t.TLSClientConfig.Certificates = make([]tls.Certificate, 1)
+		t.TLSClientConfig.Certificates[0] = crt
+
+		caByte, err := os.ReadFile(tlsConfig.CAPath)
+		if err != nil {
+			return err
+		}
+
+		// load system CAs
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+
+		if !pool.AppendCertsFromPEM(caByte) {
+			return fmt.Errorf("Cannot append CA certificate to pool")
+		}
+
+		if err != nil {
+			return fmt.Errorf("Cannot load CA cert [%q]: %w", tlsConfig.CAPath, err)
+		}
+		t.TLSClientConfig.ClientCAs = pool
+	}
+
+	client := &http.Client{Transport: t}
+
+	url := "https://" + serverAddr
+
+	return serverRequest(client, url)
 }

--- a/pkg/healthcheck/service.go
+++ b/pkg/healthcheck/service.go
@@ -98,12 +98,11 @@ func (hs *hcService) Shutdown() {
 	log.Info("Initiating shutdown of health check daemon ...")
 	close(hs.shutdownChan)
 
-	if hs.hcServer != nil && hs.hcServerRunning {
+	if hs.hcServer != nil {
 		forcedCtx, cancel := context.WithCancel(context.Background())
 		cancel() // force shutdown health check server without delay
 		hs.hcServer.SetKeepAlivesEnabled(false)
-		err := hs.hcServer.Shutdown(forcedCtx)
-		if err != nil && err != context.Canceled {
+		if err := hs.hcServer.Shutdown(forcedCtx); err != nil && err != context.Canceled {
 			log.Errorf("Failed to shutdown health check server: %s", err.Error())
 		}
 	}

--- a/pkg/healthcheck/service.go
+++ b/pkg/healthcheck/service.go
@@ -99,6 +99,8 @@ func (hs *hcService) Shutdown() {
 	close(hs.shutdownChan)
 
 	if hs.hcServer != nil {
+		// As hs.hcServer should always shutdown forcefully, NO need to check hs.hcServerRunning == true
+
 		forcedCtx, cancel := context.WithCancel(context.Background())
 		cancel() // force shutdown health check server without delay
 		hs.hcServer.SetKeepAlivesEnabled(false)
@@ -107,7 +109,7 @@ func (hs *hcService) Shutdown() {
 		}
 	}
 
-	// wait for graceful shutdown
+	// wait for forceful shutdown
 	hs.shutdownWg.Wait()
 }
 

--- a/pkg/healthcheck/service.go
+++ b/pkg/healthcheck/service.go
@@ -84,7 +84,7 @@ func (hs *hcService) Start(ctx context.Context) error {
 			log.Info("Stopped health check server")
 		}()
 
-		if err := daemon.WaitForServerReady(hs.hcServer.Addr, false); err != nil {
+		if err := daemon.WaitForServerReady(hs.hcServer.Addr); err != nil {
 			log.Errorf("Failed to confirm health check server ready: %s", err.Error())
 			return err
 		}

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -119,7 +119,7 @@ func (ms *metricsService) Start(ctx context.Context) error {
 			log.Info("Stopped metrics exporter server")
 		}()
 
-		if err := daemon.WaitForServerReady(ms.exporter.ListenAddress, false); err != nil {
+		if err := daemon.WaitForServerReady(ms.exporter.ListenAddress); err != nil {
 			log.Errorf("Failed to confirm metrics exporter server ready: %s", err.Error())
 			return err
 		}

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -133,7 +133,7 @@ func (ms *metricsService) Shutdown() {
 	log.Info("Initiating shutdown of metrics exporter daemon ...")
 	close(ms.shutdownChan)
 
-	if ms.exporter != nil && ms.exporterRunning {
+	if ms.exporter != nil {
 		err := ms.exporter.Shutdown() // context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
 		// P.S. Make sure to use the httpChecker to ensure ListenAndServe() is finished before Shutdown() is called. If ListenAndServe() does not finish creating the server object before Shutdown() is called, the internal server field will be nil and Shutdown() be a no-op. ListenAndServe() will block and cause deadlock.
 		if err != nil {

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -134,7 +134,10 @@ func (ms *metricsService) Shutdown() {
 	close(ms.shutdownChan)
 
 	if ms.exporter != nil {
-		err := ms.exporter.Shutdown() // context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
+		// As ms.exporter.Shutdown() can ONLY shutdown gracefully, NO need to check ms.exporterRunning == true
+
+		err := ms.exporter.Shutdown()
+		// context.Background() is used, no timeout. refer to https://github.com/enix/x509-certificate-exporter/blob/33dd533/internal/exporter.go#L111
 		// P.S. Make sure to use the httpChecker to ensure ListenAndServe() is finished before Shutdown() is called. If ListenAndServe() does not finish creating the server object before Shutdown() is called, the internal server field will be nil and Shutdown() be a no-op. ListenAndServe() will block and cause deadlock.
 		if err != nil {
 			log.Errorf("Failed to shutdown metrics exporter server: %s", err.Error())

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -257,20 +257,32 @@ func (ts *tokenService) Shutdown() {
 	log.Info("Initiating shutdown of token provider daemon ...")
 	close(ts.shutdownChan)
 
-	if ts.tokenServer != nil && ts.tokenServerRunning {
-		log.Infof("Delaying token provider server shutdown for %s to shutdown gracefully ...", ts.idCfg.TokenServer.ShutdownDelay.String())
-		time.Sleep(ts.idCfg.TokenServer.ShutdownDelay)
+	if ts.tokenServer != nil {
+		if ts.tokenServerRunning {
+			log.Infof("Delaying token provider server shutdown for %s to shutdown gracefully ...", ts.idCfg.TokenServer.ShutdownDelay.String())
+			time.Sleep(ts.idCfg.TokenServer.ShutdownDelay)
 
-		ctx, cancel := context.WithTimeout(context.Background(), ts.idCfg.TokenServer.ShutdownTimeout)
-		defer cancel()
-		ts.tokenServer.SetKeepAlivesEnabled(false)
-		if err := ts.tokenServer.Shutdown(ctx); err != nil {
-			// graceful shutdown error or timeout should be fatal
-			log.Errorf("Failed to shutdown token provider server: %s", err.Error())
+			ctx, cancel := context.WithTimeout(context.Background(), ts.idCfg.TokenServer.ShutdownTimeout)
+			defer cancel()
+			ts.tokenServer.SetKeepAlivesEnabled(false)
+			if err := ts.tokenServer.Shutdown(ctx); err != nil {
+				// graceful shutdown error or timeout should be fatal
+				log.Errorf("Failed to shutdown token provider server gracefully: %s", err.Error())
+			}
+		} else {
+			log.Info("Force shutdown token provider server...")
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			ts.tokenServer.SetKeepAlivesEnabled(false)
+			if err := ts.tokenServer.Shutdown(ctx); err != nil && err != context.Canceled {
+				// forceful shutdown error
+				log.Errorf("Failed to shutdown token provider server forcefully: %s", err.Error())
+			}
 		}
 	}
 
-	// wait for graceful shutdown
+	// wait for graceful/forceful shutdown
 	ts.shutdownWg.Wait()
 }
 

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -190,7 +190,7 @@ func (ts *tokenService) Start(ctx context.Context) error {
 			log.Info("Stopped token provider server")
 		}()
 
-		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.tokenServer.TLSConfig != nil); err != nil {
+		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS.Use); err != nil {
 			log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
 			return err
 		}

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -190,9 +190,16 @@ func (ts *tokenService) Start(ctx context.Context) error {
 			log.Info("Stopped token provider server")
 		}()
 
-		if err := daemon.WaitForServerReady(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS.Use); err != nil {
-			log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
-			return err
+		if ts.idCfg.TokenServer.TLS.Use {
+			if err := daemon.WaitForServerReadyWithTLS(ts.tokenServer.Addr, ts.idCfg.TokenServer.TLS); err != nil {
+				log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
+				return err
+			}
+		} else {
+			if err := daemon.WaitForServerReady(ts.tokenServer.Addr); err != nil {
+				log.Errorf("Failed to confirm token provider server ready: %s", err.Error())
+				return err
+			}
 		}
 		ts.tokenServerRunning = true
 	}

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -272,10 +272,10 @@ func (ts *tokenService) Shutdown() {
 		} else {
 			log.Info("Force shutdown token provider server...")
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
+			forcedCtx, cancel := context.WithCancel(context.Background())
+			cancel() // force shutdown token provider server without delay
 			ts.tokenServer.SetKeepAlivesEnabled(false)
-			if err := ts.tokenServer.Shutdown(ctx); err != nil && err != context.Canceled {
+			if err := ts.tokenServer.Shutdown(forcedCtx); err != nil && err != context.Canceled {
 				// forceful shutdown error
 				log.Errorf("Failed to shutdown token provider server forcefully: %s", err.Error())
 			}


### PR DESCRIPTION
# Description

In the settings described below, k8s-athenz-sia requires a client certificate.
```
TOKEN_SERVER_TLS_CA_PATH=ca-cert.pem
TOKEN_SERVER_TLS_CERT_PATH=server-cert.pem
TOKEN_SERVER_TLS_KEY_PATH=server-key.pem
```

However, the startup check logic of the token server does not set the client certificate, resulting in the output of logs like below and a failure in the startup check.
```
ERROR[2024-11-28T12:41:45+09:00] Failed to confirm token provider server ready: Get "https://localhost:8080": remote error: tls: certificate required
```

In this PR, we set our own server certificate as the client certificate to successfully pass the startup check logic.

## Assignees
- [ ] `Assignees` is set

## Type of changes
- [ ] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
