### PR TITLE
Modify the logic to validate the size comparison between the token's expiration time and refresh frequency so that it is executed only in init mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,16 +259,18 @@ func (idCfg *IdentityConfig) parseRawValues() (err error) {
 
 func (idCfg *IdentityConfig) validateAndInit() (err error) {
 
-	if idCfg.TokenExpiry != 0 && idCfg.TokenRefresh >= idCfg.TokenExpiry {
+	//When SIA starts in refresh mode, the token refresh interval must be less than the token's expiration time.
+	// In refresh mode, SIA periodically updates the token and refreshes the cache.
+	// If the token refresh interval is greater than the token's expiration time, the token may temporarily expire.
+	// Considering the time taken for the token refresh process, if the token refresh interval is greater than or equal to the token's expiration time, SIA should terminate abnormally.
+	// If the token's expiration time is set to 0, the server-side default value will be used as the expiration time, and the above validation will not be performed.
+	if !idCfg.Init && idCfg.TokenExpiry != 0 && idCfg.TokenRefresh >= idCfg.TokenExpiry {
 		return fmt.Errorf("Invalid TokenRefresh[%s] >= TokenExpiry[%s]", idCfg.TokenRefresh.String(), idCfg.TokenExpiry.String())
 	}
 
-	// TODO: clarify unused logic
-	// pollTokenInterval := idCfg.TokenRefresh
-	// if pollTokenInterval > DEFAULT_POLL_TOKEN_INTERVAL {
-	// 	pollTokenInterval = DEFAULT_POLL_TOKEN_INTERVAL
-	// }
-
+	// SIA may read certificates issued by external components.
+	// The frequency of re-reading updated certificates must be below a certain value.
+	// The maximum frequency for re-reading is managed by the util.DefaultPollInterval.
 	pollInterval := idCfg.Refresh
 	if pollInterval > util.DefaultPollInterval {
 		pollInterval = util.DefaultPollInterval
@@ -306,6 +308,8 @@ func (idCfg *IdentityConfig) validateAndInit() (err error) {
 		}
 		return errors.New("Deleted X.509 certificate that already existed.")
 	}
+	// If SIA is not in init mode, it needs to update the certificate and issue tokens.
+	// Therefore, if the certificate output to the file cannot be read, it should terminate abnormally.
 	if !idCfg.Init && err != nil {
 		return fmt.Errorf("Unable to read key and cert: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,7 +259,7 @@ func (idCfg *IdentityConfig) parseRawValues() (err error) {
 
 func (idCfg *IdentityConfig) validateAndInit() (err error) {
 
-	//When SIA starts in refresh mode, the token refresh interval must be less than the token's expiration time.
+	// When SIA starts in refresh mode, the token refresh interval must be less than the token's expiration time.
 	// In refresh mode, SIA periodically updates the token and refreshes the cache.
 	// If the token refresh interval is greater than the token's expiration time, the token may temporarily expire.
 	// Considering the time taken for the token refresh process, if the token refresh interval is greater than or equal to the token's expiration time, SIA should terminate abnormally.


### PR DESCRIPTION
# Description
We have modified the system so that when starting in init mode, it no longer performs a size comparison between the TokenRefresh and TokenExpiry settings at startup. 
- The size comparison between TokenRefresh and TokenExpiry is a logic used to prevent the token from expiring before the cache is updated when starting in refresh mode. Therefore, it is not necessary to execute the above comparison and validation logic in init mode.

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
