### PR TITLE
Upgrade x509-certificate-exporter to v3.18.1 and upload/download-artifact to v4

### DIFF
--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -260,7 +260,7 @@ jobs:
       # https://github.com/actions/upload-artifact
       -
         name: Upload digests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests
           path: /tmp/digests/*

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -262,7 +262,7 @@ jobs:
         name: Upload digests
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ strategy.job-index }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -294,7 +294,8 @@ jobs:
         name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          name: digests-*
+          merge-multiple: true
           path: /tmp/digests
 
       -

--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -292,7 +292,7 @@ jobs:
       # https://github.com/actions/download-artifact
       -
         name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -84,14 +84,17 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		MaxCacheDuration:      time.Duration(0),
 		ExposeRelativeMetrics: true,
 		ExposeErrorMetrics:    true,
-		KubeSecretTypes: []string{
-			"kubernetes.io/tls:tls.crt",
-		},
+		KubeSecretTypes:       make([]internal.KubeSecretType, 1),
 		KubeIncludeNamespaces: []string{},
 		KubeExcludeNamespaces: []string{},
 		KubeIncludeLabels:     []string{},
 		KubeExcludeLabels:     []string{},
 	}
+	kst, err := internal.ParseSecretType("kubernetes.io/tls:tls.crt")
+	if err != nil {
+		return nil, fmt.Errorf("x509-certificate-exporter ParseSecretType error: %w", err)
+	}
+	exporter.KubeSecretTypes[0] = kst
 
 	if idCfg.RoleCert.Use {
 		for _, dr := range idCfg.RoleCert.TargetDomainRoles {

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 
@@ -84,17 +85,12 @@ func New(ctx context.Context, idCfg *config.IdentityConfig) (daemon.Daemon, erro
 		MaxCacheDuration:      time.Duration(0),
 		ExposeRelativeMetrics: true,
 		ExposeErrorMetrics:    true,
-		KubeSecretTypes:       make([]internal.KubeSecretType, 1),
+		KubeSecretTypes:       []internal.KubeSecretType{{Type: "kubernetes.io/tls", Regexp: regexp.MustCompile(`tls\.crt`)}},
 		KubeIncludeNamespaces: []string{},
 		KubeExcludeNamespaces: []string{},
 		KubeIncludeLabels:     []string{},
 		KubeExcludeLabels:     []string{},
 	}
-	kst, err := internal.ParseSecretType("kubernetes.io/tls:tls.crt")
-	if err != nil {
-		return nil, fmt.Errorf("x509-certificate-exporter ParseSecretType error: %w", err)
-	}
-	exporter.KubeSecretTypes[0] = kst
 
 	if idCfg.RoleCert.Use {
 		for _, dr := range idCfg.RoleCert.TargetDomainRoles {


### PR DESCRIPTION
# Description

- from: [v3.17.0](https://github.com/enix/x509-certificate-exporter/commits/v3.17.0), `8f97b98` => current version used in by SIA `c0ca500` => [v3.18.0](https://github.com/enix/x509-certificate-exporter/commits/v3.18.0), `476b093` => [v3.18.1](https://github.com/enix/x509-certificate-exporter/commits/v3.18.1), `e2f8c412`
  - releases: https://github.com/enix/x509-certificate-exporter/releases
    - [related changes](https://github.com/enix/x509-certificate-exporter/pull/287/files#diff-5e3b74e65c364421f5a4e20512bfc447cfedc75d2734716d740f22f4b2fb3226R995)
- upgrade `actions/upload-artifact@v3` and `actions/download-artifact@v3` => `v4`
  - [Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x] Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
