### PR TITLE
remove duplicated package comments

### DIFF
--- a/pkg/config/derived-k8s-secret-backup.go
+++ b/pkg/config/derived-k8s-secret-backup.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/derived-role-cert.go
+++ b/pkg/config/derived-role-cert.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/derived-service-cert.go
+++ b/pkg/config/derived-service-cert.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/derived-target-domain-roles.go
+++ b/pkg/config/derived-target-domain-roles.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/derived-token-file.go
+++ b/pkg/config/derived-token-file.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/derived-token-server.go
+++ b/pkg/config/derived-token-server.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 import (

--- a/pkg/config/dervied.go
+++ b/pkg/config/dervied.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines all the configuration parameters. It reads configuration from environment variables and command-line arguments.
 package config
 
 // loadDerivedConfig loads functions from files with prefix "derived-" under /pkg/config


### PR DESCRIPTION
# Description

as title, package comment is written in `doc.go` already
https://github.com/AthenZ/k8s-athenz-sia/blob/8af30bdec5271c8fe725aef6b3c1efeaf8d19ea5/pkg/config/doc.go#L15-L16

## Assignees
- [x] `Assignees` is set

## Type of changes
- [x Apply one or more `labels` of the following that fits:
  - `bug`: Bug fix
  - `dependencies`: Dependency upgrades
  - `documentation`: Documentation changes
  - `enhancement`: New Feature
  - `good first issue`: First contribution
  - `logging`: Log changes
  - `refactor`: Refactoring (no functional changes, no api changes)

### Flags
```
- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code
```
---

## Checklist
```
- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
```

## Checklist for maintainer
```
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
```
